### PR TITLE
Don't autoremove brackets if not autocompleting

### DIFF
--- a/lib/bracket-matcher.coffee
+++ b/lib/bracket-matcher.coffee
@@ -105,7 +105,7 @@ class BracketMatcher
     previousCharacter = previousCharacters.slice(-1)
 
     hasEscapeSequenceBeforeCursor = previousCharacters.match(/\\/g)?.length >= 1 # To guard against the "\\" sequence
-    if (@pairedCharacters[previousCharacter] is nextCharacter) and not hasEscapeSequenceBeforeCursor
+    if (@pairedCharacters[previousCharacter] is nextCharacter) and not hasEscapeSequenceBeforeCursor and atom.config.get('bracket-matcher.autocompleteBrackets')
       @editor.transact =>
         @editor.moveCursorLeft()
         @editor.delete()

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -709,10 +709,23 @@ describe "bracket matching", ->
           expect(editor.getText()).toBe 'void main() {}'
 
   describe "matching bracket deletion", ->
-    it "deletes the end bracket when it directly proceeds a begin bracket that is being backspaced", ->
+    it "deletes the end bracket when it directly precedes a begin bracket that is being backspaced", ->
       buffer.setText("")
       editor.setCursorBufferPosition([0, 0])
       editor.insertText '{'
       expect(buffer.lineForRow(0)).toBe "{}"
       editor.backspace()
       expect(buffer.lineForRow(0)).toBe ""
+
+    it "does not delete end bracket even if it directly precedes a begin bracket if autocomplete is turned off", ->
+      atom.config.set 'bracket-matcher.autocompleteBrackets', false
+      buffer.setText("")
+      editor.setCursorBufferPosition([0, 0])
+      editor.insertText "{"
+      expect(buffer.lineForRow(0)).toBe "{"
+      editor.insertText "}"
+      expect(buffer.lineForRow(0)).toBe "{}"
+      editor.setCursorBufferPosition([0, 1])
+      editor.backspace()
+      expect(buffer.lineForRow(0)).toBe "}"
+


### PR DESCRIPTION
If the configuration for autocompleting matching brackets
is turned off, it should not autoremove brackets either.
