### PR TITLE
Matching pairs are not highlighted after moving from a selection to a pair.

### DIFF
--- a/lib/bracket-matcher-view.coffee
+++ b/lib/bracket-matcher-view.coffee
@@ -30,6 +30,9 @@ class BracketMatcherView
 
     @subscriptions.add @editor.onDidChangeGrammar =>
       @updateMatch()
+      
+    @subscriptions.add @editor.onDidChangeSelectionRange =>
+      @updateMatch()      
 
     @subscribeToCursor()
 

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -115,6 +115,13 @@ describe "bracket matching", ->
 
         editor.setCursorBufferPosition([0,29])
         expectHighlights([0,28], [12,0])
+    
+    describe "when the cursor moves off (clears) a selection next to a starting or ending pair", ->
+      it "highlights the starting pair and ending pair", ->
+        editor.moveToEndOfLine()
+        editor.selectLeft()
+        editor.getLastCursor().clearSelection()
+        expectHighlights([0,28], [12,0])
 
     describe "HTML/XML tag matching", ->
       beforeEach ->


### PR DESCRIPTION
Selecting a bracket clears the pair matching (correct) - but then pressing the left or right arrows to move the cursor and clear the selection does not highlight the pair like it should.

![nobracketsafterselectionbug](https://cloud.githubusercontent.com/assets/286180/6050270/281cf164-ac8c-11e4-9c78-1f6d7374a41d.gif)
