### PR TITLE
:bug: Bracket matching honors/ignores brackets in comments. Fixes #78

### DIFF
--- a/spec/fixtures/sample.js
+++ b/spec/fixtures/sample.js
@@ -3,7 +3,7 @@ var quicksort = function () {
     if (items.length <= 1) return items;
     var pivot = items.shift(), current, left = [], right = [];
     while(items.length > 0) {
-      current = items.shift();
+      current = items.shift(); // {
       current < pivot ? left.push(current) : right.push(current);
     }
     return sort(left).concat(pivot).concat(sort(right));


### PR DESCRIPTION
See #78 for detailed description.

Bracket matching now distinguishes between bracket nesting in and out of comments. (What happens in the comments, stays in the comments.)

The effect should be of two different namespaces: Open/closing brackets in comments will match with each other, even across different comments and multiple lines. Any bracket matching where the cursor is not in a comment will ignore comments completely.
