### PR TITLE
String interpolation support to LiveScript

### DIFF
--- a/lib/bracket-matcher.coffee
+++ b/lib/bracket-matcher.coffee
@@ -186,6 +186,8 @@ class BracketMatcher
         'string.regexp.interpolated.ruby'
         'string.quoted.double.coffee'
         'string.unquoted.heredoc.ruby'
+        'string.quoted.double.livescript'
+        'string.quoted.double.heredoc.livescript'
       ]
       @interpolatedStringSelector = SelectorCache.get(segments.join(' | '))
     @interpolatedStringSelector.matches(@editor.getLastCursor().getScopeDescriptor().getScopesArray())


### PR DESCRIPTION
This is both a pull request and a question, whether this is the right way to do it.
Language packages [already have those configured as snippets](https://github.com/atom/language-coffee-script/blob/master/snippets/language-coffee-script.cson#L86-L89), but they don't quite work as we'd like.