### PR TITLE
Update bracket-matcher.cson

### DIFF
--- a/keymaps/bracket-matcher.cson
+++ b/keymaps/bracket-matcher.cson
@@ -10,7 +10,9 @@
 '.platform-linux atom-text-editor':
   'alt-ctrl-.': 'bracket-matcher:close-tag'
   'alt-ctrl-backspace': 'bracket-matcher:remove-matching-brackets'
+  'ctrl-shift-m': 'bracket-matcher:select-inside-brackets'
 
 '.platform-win32 atom-text-editor':
   'alt-ctrl-.': 'bracket-matcher:close-tag'
+  'ctrl-shift-m': 'bracket-matcher:select-inside-brackets'
   'alt-ctrl-backspace': 'bracket-matcher:remove-matching-brackets'


### PR DESCRIPTION
Added ctrl-shift-m binding for bracket-matcher:select-inside-brackets for windows and linux platforms.  (Both platforms had been lacking any such shortcuts until now)