### PR TITLE
Fix #124: Add 'select-inside-brackets' keys for Windows and Linux

### DIFF
--- a/keymaps/bracket-matcher.cson
+++ b/keymaps/bracket-matcher.cson
@@ -8,9 +8,11 @@
   'ctrl-backspace': 'bracket-matcher:remove-matching-brackets'
 
 '.platform-linux atom-text-editor':
+  'ctrl-alt-m': 'bracket-matcher:select-inside-brackets'
   'alt-ctrl-.': 'bracket-matcher:close-tag'
   'alt-ctrl-backspace': 'bracket-matcher:remove-matching-brackets'
 
 '.platform-win32 atom-text-editor':
+  'ctrl-alt-m': 'bracket-matcher:select-inside-brackets'
   'alt-ctrl-.': 'bracket-matcher:close-tag'
   'alt-ctrl-backspace': 'bracket-matcher:remove-matching-brackets'


### PR DESCRIPTION
It fixes #124 

I have been using this for a couple of months on Linux and it works great, I tested on Windows and it works fine too =D