### PR TITLE
Add Select Inside Brackets to Selection menu

### DIFF
--- a/menus/bracket-matcher.cson
+++ b/menus/bracket-matcher.cson
@@ -7,9 +7,15 @@
         { 'label': 'Go To Matching Bracket', 'command': 'bracket-matcher:go-to-matching-bracket' }
         { 'label': 'Select Inside Brackets', 'command': 'bracket-matcher:select-inside-brackets' }
         { 'label': 'Remove Brackets From Selection', 'command': 'bracket-matcher:remove-brackets-from-selection' }
-        { 'label': 'Close Current Tag', 'command': 'bracket-matcher:close-tag'}
-        { 'label': 'Remove Matching Brackets', 'command': 'bracket-matcher:remove-matching-brackets'}
+        { 'label': 'Close Current Tag', 'command': 'bracket-matcher:close-tag' }
+        { 'label': 'Remove Matching Brackets', 'command': 'bracket-matcher:remove-matching-brackets' }
       ]
+    ]
+  },
+  {
+    'label': 'Selection'
+    'submenu': [
+        { 'label': 'Select Inside Brackets', 'command': 'bracket-matcher:select-inside-brackets' }
     ]
   }
 ]


### PR DESCRIPTION
This adds "Select Inside Brackets" to the Selection menu – this should aid in discoverability. (I actually didn't know this command existed until a recent PR, because I had assumed that all of Atom's selection modes were in the Selection menu.)

/cc @atom/non-github-maintainers 