### PR TITLE
Update bracket-matcher.atom-text-editor.less

### DIFF
--- a/styles/bracket-matcher.atom-text-editor.less
+++ b/styles/bracket-matcher.atom-text-editor.less
@@ -1,4 +1,6 @@
 .bracket-matcher .region {
-  border-bottom: 1px dotted lime;
-  position: absolute;
+  border: 1px solid red;
+  margin: 0 0 0 -2px;
+  background-color: rgba(0, 255, 0, 0.4);
+  z-index:100;
 }


### PR DESCRIPTION
The code only highlights the opposite tag, because highlight has a higher z-index than the bracket matcher.
Related to this discussion.