### PR TITLE
#124: change bracket-matcher:select-inside-brackets to ctrl-shift-m

### DIFF
--- a/keymaps/bracket-matcher.cson
+++ b/keymaps/bracket-matcher.cson
@@ -8,11 +8,11 @@
   'ctrl-backspace': 'bracket-matcher:remove-matching-brackets'
 
 '.platform-linux atom-text-editor':
-  'ctrl-alt-m': 'bracket-matcher:select-inside-brackets'
+  'ctrl-shift-m': 'bracket-matcher:select-inside-brackets'
   'alt-ctrl-.': 'bracket-matcher:close-tag'
   'alt-ctrl-backspace': 'bracket-matcher:remove-matching-brackets'
 
 '.platform-win32 atom-text-editor':
-  'ctrl-alt-m': 'bracket-matcher:select-inside-brackets'
+  'ctrl-shift-m': 'bracket-matcher:select-inside-brackets'
   'alt-ctrl-.': 'bracket-matcher:close-tag'
   'alt-ctrl-backspace': 'bracket-matcher:remove-matching-brackets'


### PR DESCRIPTION
Two pull requests that goes together : 
  - **markdown-preview**: only activate `ctrl-shift-m` when in markdown editing context (to free that shortkey for all other grammars)
  - **bracket-matcher**: make use of `ctrl-shift-m` for *select-inside-brackets* action