### PR TITLE
:apple: Use `alt-ctrl-backspace` for removing matching brackets

### DIFF
--- a/keymaps/bracket-matcher.cson
+++ b/keymaps/bracket-matcher.cson
@@ -1,18 +1,16 @@
 'atom-text-editor':
   'ctrl-m': 'bracket-matcher:go-to-matching-bracket'
   'ctrl-]': 'bracket-matcher:remove-brackets-from-selection'
+  'alt-ctrl-backspace': 'bracket-matcher:remove-matching-brackets'
 
 '.platform-darwin atom-text-editor':
   'ctrl-cmd-m': 'bracket-matcher:select-inside-brackets'
   'alt-cmd-.': 'bracket-matcher:close-tag'
-  'ctrl-backspace': 'bracket-matcher:remove-matching-brackets'
 
 '.platform-linux atom-text-editor':
   'ctrl-alt-m': 'bracket-matcher:select-inside-brackets'
   'alt-ctrl-.': 'bracket-matcher:close-tag'
-  'alt-ctrl-backspace': 'bracket-matcher:remove-matching-brackets'
 
 '.platform-win32 atom-text-editor':
   'ctrl-alt-m': 'bracket-matcher:select-inside-brackets'
   'alt-ctrl-.': 'bracket-matcher:close-tag'
-  'alt-ctrl-backspace': 'bracket-matcher:remove-matching-brackets'


### PR DESCRIPTION
On Mac OS X, `ctrl-backspace` is commonly used to delete the previous
subword. Examples: Sublime Text 3, TextMate 2, and Xcode.
