### PR TITLE
:apple: Use `ctrl-cmd-backspace` for removing matching brackets

### DIFF
--- a/keymaps/bracket-matcher.cson
+++ b/keymaps/bracket-matcher.cson
@@ -5,7 +5,7 @@
 '.platform-darwin atom-text-editor':
   'ctrl-cmd-m': 'bracket-matcher:select-inside-brackets'
   'alt-cmd-.': 'bracket-matcher:close-tag'
-  'ctrl-backspace': 'bracket-matcher:remove-matching-brackets'
+  'ctrl-cmd-backspace': 'bracket-matcher:remove-matching-brackets'
 
 '.platform-linux atom-text-editor':
   'ctrl-alt-m': 'bracket-matcher:select-inside-brackets'


### PR DESCRIPTION
On Mac OS X, `ctrl-backspace` is commonly used to delete the previous
subword. Examples: Sublime Text 3, TextMate 2, and Xcode.
