### PR TITLE
Fix closing string that end with escaped char

### DIFF
--- a/.idea/watcherTasks.xml
+++ b/.idea/watcherTasks.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectTasksOptions" suppressed-tasks="CoffeeScript" />
+</project>

--- a/.idea/watcherTasks.xml
+++ b/.idea/watcherTasks.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectTasksOptions" suppressed-tasks="CoffeeScript" />
-</project>

--- a/lib/bracket-matcher.coffee
+++ b/lib/bracket-matcher.coffee
@@ -60,7 +60,8 @@ class BracketMatcher
     hasWordAfterCursor = /\w/.test(nextCharacter)
     hasWordBeforeCursor = /\w/.test(previousCharacter)
     hasQuoteBeforeCursor = previousCharacter is text[0]
-    hasEscapeSequenceBeforeCursor = previousCharacters.match(/\\/g)?.length >= 1 # To guard against the "\\" sequence
+    hasEscapeSequenceBeforeCursor = previousCharacters.match(/\\/g)?.length >= 1 # To guard against the "\\" sequence (last 2 char)
+    hasEscapeSequenceAtCursor = previousCharacter is "\\"  # To guard against the "\\" sequence (last char)
 
     if text is '#' and @isCursorOnInterpolatedString()
       autoCompleteOpeningBracket = atom.config.get('bracket-matcher.autocompleteBrackets') and not hasEscapeSequenceBeforeCursor
@@ -71,7 +72,7 @@ class BracketMatcher
       pair = @pairedCharacters[text]
 
     skipOverExistingClosingBracket = false
-    if @isClosingBracket(text) and nextCharacter is text and not hasEscapeSequenceBeforeCursor
+    if @isClosingBracket(text) and nextCharacter is text and not hasEscapeSequenceAtCursor
       if bracketMarker = _.find(@bracketMarkers, (marker) -> marker.isValid() and marker.getBufferRange().end.isEqual(cursorBufferPosition))
         skipOverExistingClosingBracket = true
 

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -645,6 +645,26 @@ describe "bracket matching", ->
           expect(buffer.lineForRow(0)).toBe '"ok"'
           expect(editor.getCursorBufferPosition()).toEqual [0, 4]
 
+        it "closes brackets with the same begin/end character correctly (last char is an escaped char)", ->
+          editor.insertText '"'
+          editor.insertText 'ok'
+          expect(buffer.lineForRow(0)).toBe '"ok"'
+          expect(editor.getCursorBufferPosition()).toEqual [0, 3]
+          editor.insertText '\\n'
+          editor.insertText '"'
+          expect(buffer.lineForRow(0)).toBe '"ok\\n"'
+          expect(editor.getCursorBufferPosition()).toEqual [0, 6]
+
+        it "closes brackets with the same begin/end character correctly (last char is backslash)", ->
+          editor.insertText '"'
+          editor.insertText 'ok'
+          expect(buffer.lineForRow(0)).toBe '"ok"'
+          expect(editor.getCursorBufferPosition()).toEqual [0, 3]
+          editor.insertText '\\'
+          editor.insertText '"'
+          expect(buffer.lineForRow(0)).toBe '"ok\\""'
+          expect(editor.getCursorBufferPosition()).toEqual [0, 5]
+
     describe "when there is text selected on a single line", ->
       it "wraps the selection with brackets", ->
         editor.setText 'text'


### PR DESCRIPTION
Possible fix for https://github.com/atom/bracket-matcher/issues/80

Looks like a off-by-one error in logic, treated as such.

- Added test for the issue80 as well as normal behavior of skipOverExistingClosingBracket 

(will remove .idea IDE folder once i know if Travis passes)