### PR TITLE
Fix double opening brace inside newly created interpolation #{}

### DIFF
--- a/lib/bracket-matcher.coffee
+++ b/lib/bracket-matcher.coffee
@@ -63,7 +63,7 @@ class BracketMatcher
     hasEscapeSequenceBeforeCursor = previousCharacters.match(/\\/g)?.length >= 1 # To guard against the "\\" sequence
 
     # if we type { inside a newly created interpolation #{}, suppress opening brace
-    if text is '{' and previousCharacters=='#\{' and @isCursorOnInterpolatedString()
+    if text is '{' and previousCharacters is '#\{' and @isCursorOnInterpolatedString()
       return false
 
     if text is '#' and @isCursorOnInterpolatedString()

--- a/lib/bracket-matcher.coffee
+++ b/lib/bracket-matcher.coffee
@@ -62,6 +62,10 @@ class BracketMatcher
     hasQuoteBeforeCursor = previousCharacter is text[0]
     hasEscapeSequenceBeforeCursor = previousCharacters.match(/\\/g)?.length >= 1 # To guard against the "\\" sequence
 
+    # if we type { inside a newly created interpolation #{}, suppress opening brace
+    if text is '{' and previousCharacters=='#\{' and @isCursorOnInterpolatedString()
+      return false
+
     if text is '#' and @isCursorOnInterpolatedString()
       autoCompleteOpeningBracket = atom.config.get('bracket-matcher.autocompleteBrackets') and not hasEscapeSequenceBeforeCursor
       text += '{'

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -852,6 +852,15 @@ describe "bracket matching", ->
           editor.undo()
           expect(editor.getText()).toBe 'foo = ""'
 
+        it "should skip opening interpolation brace if already inserted", ->
+          editor.insertText "foo = "
+          editor.insertText '"'
+          editor.insertText "#"
+          expect(editor.getText()).toBe 'foo = "#{}"'
+          editor.insertText "{"
+          editor.insertText "bar"
+          expect(editor.getText()).toBe 'foo = "#{bar}"'
+
         it "should not insert curly braces inside singly quoted string", ->
           editor.insertText "foo = "
           editor.insertText "'"

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -859,7 +859,7 @@ describe "bracket matching", ->
           expect(editor.getText()).toBe 'foo = "#{}"'
           editor.insertText "{"
           editor.insertText "bar"
-          expect(editor.getText()).toBe 'foo = "#{bar}"'
+          expect(editor.getText()).toBe 'foo = "#\{bar}"'
 
         it "should not insert curly braces inside singly quoted string", ->
           editor.insertText "foo = "


### PR DESCRIPTION
Possible fix for #109 

After `#` is completed to `#{}` suppress typing `{` that would result in that `#{{}}`
