### PR TITLE
add option to suppress bracket matching for a given insertText

### DIFF
--- a/lib/bracket-matcher.coffee
+++ b/lib/bracket-matcher.coffee
@@ -48,6 +48,7 @@ class BracketMatcher
   insertText: (text, options) =>
     return true unless text
     return true if options?.select or options?.undo is 'skip'
+    return true if options?.matchBrackets? and not options.matchBrackets
     return false if @wrapSelectionInBrackets(text)
     return true if @editor.hasMultipleCursors()
 


### PR DESCRIPTION
Fixes #163.

This little addition is enough for *vim-mode* to suppress bracket matching where inappropriate. 

Please let me know if you think this should be done differently. I can add specs if this approach is approved.