### PR TITLE
no longer rely on consolidateSelections to remove cursors in spec

### DIFF
--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -105,12 +105,12 @@ describe "bracket matching", ->
           expectHighlights([8, 42], [8, 54])
 
     describe "when the cursor is destroyed", ->
-      it "updates the highlights to use the editor's last cursor", ->
+      it "updates the highlights to use the editor's first cursor", ->
         editor.setCursorBufferPosition([0, 29])
         editor.addCursorAtBufferPosition([9, 0])
         expectHighlights([0, 28], [12, 0])
 
-        editor.consolidateSelections()
+        editor.getCursors()[0].destroy()
         expectNoHighlights()
 
         editor.setCursorBufferPosition([0, 29])

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -105,7 +105,7 @@ describe "bracket matching", ->
           expectHighlights([8, 42], [8, 54])
 
     describe "when the cursor is destroyed", ->
-      it "updates the highlights to use the editor's first cursor", ->
+      it "updates the highlights to use the editor's last cursor", ->
         editor.setCursorBufferPosition([0, 29])
         editor.addCursorAtBufferPosition([9, 0])
         expectHighlights([0, 28], [12, 0])


### PR DESCRIPTION
Related to the PR on atom core https://github.com/atom/atom/pull/8604

I have a PR on atom core that changes the behavior of `consolidateSelections`. That build failed because  bracket matcher is using that function to remove cursors in its spec. 

This PR just removes the cursor manually in the spec - so as not to rely on `consolidateSelections`