### PR TITLE
Add descriptions for config settings

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -6,12 +6,15 @@ module.exports =
     autocompleteBrackets:
       type: 'boolean'
       default: true
+      description: 'Autocomplete bracket and quote characters, such as `(` and `)`, and `"`.'
     autocompleteSmartQuotes:
       type: 'boolean'
       default: true
+      description: 'Autocomplete smart quote characters, such as `“` and `”`, and `«` and `»`.'
     wrapSelectionsInBrackets:
       type: 'boolean'
       default: true
+      description: 'Wrap selected text in brackets or quotes when the editor contains selections and the openeing bracket or quote is typed.'
 
   activate: ->
     atom.workspace.observeTextEditors (editor) ->


### PR DESCRIPTION
As a followup to atom/atom#9096, this adds descriptions for config settings in this package.
