### PR TITLE
wrap selected text in *, _, and ~

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ You can toggle whether English/French style quotation marks (`“”`, `‘’`,
 and `‹›`) are autocompleted via the *Autocomplete Smart Quotes*  setting in the
 settings view.
 
+Autocompletes `*`, `_`, and  `~`, but only when there is an active selection (togglable via the *Wrap Selections In Markdown Punctuation* setting).
+
 Use `ctrl-m` to jump to the bracket matching the one adjacent to the cursor.
 It jumps to the nearest enclosing bracket when there's no adjacent bracket,
 

--- a/lib/bracket-matcher.coffee
+++ b/lib/bracket-matcher.coffee
@@ -23,6 +23,11 @@ class BracketMatcher
     "«": "»"
     "‹": "›"
 
+  selectionOnlyPairs:
+    "*": "*"
+    "_": "_"
+    "~": "~"
+
   toggleQuotes: (includeSmartQuotes) ->
     if includeSmartQuotes
       @pairedCharacters = _.extend({}, @defaultPairs, @smartQuotePairs)
@@ -147,10 +152,14 @@ class BracketMatcher
   wrapSelectionInBrackets: (bracket) ->
     return false unless atom.config.get('bracket-matcher.wrapSelectionsInBrackets')
 
+    doMarkdownPunctuation = atom.config.get('bracket-matcher.wrapSelectionsInMarkdownPunctuation')
+
     if bracket is '#'
       return false unless @isCursorOnInterpolatedString()
       bracket = '#{'
       pair = '}'
+    else if @selectionOnlyPairs[bracket] && doMarkdownPunctuation
+      pair = @selectionOnlyPairs[bracket]
     else
       return false unless @isOpeningBracket(bracket)
       pair = @pairedCharacters[bracket]

--- a/lib/bracket-matcher.coffee
+++ b/lib/bracket-matcher.coffee
@@ -158,7 +158,7 @@ class BracketMatcher
       return false unless @isCursorOnInterpolatedString()
       bracket = '#{'
       pair = '}'
-    else if @selectionOnlyPairs[bracket] && doMarkdownPunctuation
+    else if @selectionOnlyPairs[bracket] and doMarkdownPunctuation
       pair = @selectionOnlyPairs[bracket]
     else
       return false unless @isOpeningBracket(bracket)

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -15,6 +15,10 @@ module.exports =
       type: 'boolean'
       default: true
       description: 'Wrap selected text in brackets or quotes when the editor contains selections and the openeing bracket or quote is typed.'
+    wrapSelectionsInMarkdownPunctuation:
+      type: 'boolean'
+      default: true
+      description: 'Wrap selected text in *, _, or ~ when the editor contains selections those characters are typed.'
 
   activate: ->
     atom.workspace.observeTextEditors (editor) ->

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -902,6 +902,41 @@ describe "bracket matching", ->
           expect(editor.getText()).toBe 'foo = "a bar"\nfoo = "a bar"'
           expect(editor.getSelectedBufferRange()).toEqual [[0, 9], [1, 12]]
 
+    describe "when inserting Markdown punctuation", ->
+      describe "when there is a selection", ->
+        beforeEach ->
+          atom.config.set('bracket-matcher.wrapSelectionsInMarkdownPunctuation', true)
+          editor.setText 'text'
+          editor.moveToBottom()
+          editor.selectToTop()
+          editor.selectAll()
+
+        it "should wrap the selection in asterisks", ->
+          editor.insertText '*'
+          expect(buffer.getText()).toBe '*text*'
+
+        it "should wrap the selection in underscores", ->
+          editor.insertText '_'
+          expect(buffer.getText()).toBe '_text_'
+
+        it "should wrap the selection in tildes", ->
+          editor.insertText '~'
+          expect(buffer.getText()).toBe '~text~'
+
+        describe "when wrapSelectionsInMarkdownPunctuation is false", ->
+          it "should not insert Markdown characters", ->
+            atom.config.set('bracket-matcher.wrapSelectionsInMarkdownPunctuation', false)
+            editor.insertText '*'
+            expect(buffer.getText()).toBe '*'
+
+      describe "when there is no selection", ->
+        it "should not insert any extra Markdown punctuation", ->
+          atom.config.set('bracket-matcher.wrapSelectionsInMarkdownPunctuation', true)
+          editor.setText '  '
+          editor.setCursorBufferPosition([0, 1])
+          editor.insertText '*'
+          expect(buffer.getText()).toBe ' * '
+
   describe "matching bracket deletion", ->
     it "deletes the end bracket when it directly precedes a begin bracket that is being backspaced", ->
       buffer.setText("")


### PR DESCRIPTION
Hi,

I keep finding my self expecting the Markdown highlighting and strike-out characters `*`, `_`, and `~` to have the same wrapping behaviour as brackets and quotes when there's a text selection, so I thought it would be a useful addition to bracket-matcher.

![ezgif com-optimize](https://cloud.githubusercontent.com/assets/280206/11319777/c36c9548-907a-11e5-8ee5-11c9f261dc23.gif)

