### PR TITLE
Prevent escaped character from incurring an extra quotation mark

### DIFF
--- a/lib/bracket-matcher.coffee
+++ b/lib/bracket-matcher.coffee
@@ -71,7 +71,7 @@ class BracketMatcher
       pair = @pairedCharacters[text]
 
     skipOverExistingClosingBracket = false
-    if @isClosingBracket(text) and nextCharacter is text and not hasEscapeSequenceBeforeCursor
+    if @isClosingBracket(text) and nextCharacter is text and (previousCharacter isnt '\\' or '\\\\' is previousCharacters)
       if bracketMarker = _.find(@bracketMarkers, (marker) -> marker.isValid() and marker.getBufferRange().end.isEqual(cursorBufferPosition))
         skipOverExistingClosingBracket = true
 

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -582,6 +582,24 @@ describe "bracket matching", ->
         expect(buffer.lineForRow(0)).toBe "''"
         expect(editor.getCursorBufferPosition()).toEqual([0, 1])
 
+    describe "when the previous character is a backslash", ->
+      it "doesn't insert a quote to match the escaped quote and overwrites the end quote", ->
+        editor.buffer.setText('')
+        editor.insertText '\"'
+        editor.insertText '\\'
+        editor.insertText '\"'
+        editor.insertText '\"'
+        expect(buffer.lineForRow(0)).toBe '\"\\\"\"'
+
+      describe "when the character before that is also a backslash", ->
+        it "inserts a matching quote and overwrites it", ->
+          editor.buffer.setText('')
+          editor.insertText '\"'
+          editor.insertText '\\'
+          editor.insertText '\\'
+          editor.insertText '\"'
+          expect(buffer.lineForRow(0)).toBe '\"\\\\\"'
+
     describe "when the cursor is on a closing bracket and a closing bracket is inserted", ->
       describe "when the closing bracket was there previously", ->
         it "inserts a closing bracket", ->


### PR DESCRIPTION
This change should cause the bracket matcher to do what we want when strings end in escape sequences.

Particularly, sequences like `"\\"` and `'\''` should now insert the trailing quote when necessary.  Also, the terminating quote should be properly overwritten.
