### PR TITLE
Disable bracket matching when next character is a quote/opening bracket

### DIFF
--- a/lib/bracket-matcher.coffee
+++ b/lib/bracket-matcher.coffee
@@ -56,18 +56,22 @@ class BracketMatcher
     nextCharacter = @editor.getTextInBufferRange([cursorBufferPosition, cursorBufferPosition.traverse([0, 1])])
 
     previousCharacter = previousCharacters.slice(-1)
-
-    hasWordAfterCursor = /\w/.test(nextCharacter)
+    hasWordAfterCursor = /\S/.test(nextCharacter)
     hasWordBeforeCursor = /\w/.test(previousCharacter)
     hasQuoteBeforeCursor = previousCharacter is text[0]
     hasEscapeSequenceBeforeCursor = previousCharacters.match(/\\/g)?.length >= 1 # To guard against the "\\" sequence
+    hasClosingBracketAfterCursor = do (@pairsToIndent) ->
+        for op, cl of pairsToIndent
+            if cl is nextCharacter[0]
+                return true
+        return false
 
     if text is '#' and @isCursorOnInterpolatedString()
       autoCompleteOpeningBracket = atom.config.get('bracket-matcher.autocompleteBrackets') and not hasEscapeSequenceBeforeCursor
       text += '{'
       pair = '}'
     else
-      autoCompleteOpeningBracket = atom.config.get('bracket-matcher.autocompleteBrackets') and @isOpeningBracket(text) and not hasWordAfterCursor and not (@isQuote(text) and (hasWordBeforeCursor or hasQuoteBeforeCursor)) and not hasEscapeSequenceBeforeCursor
+      autoCompleteOpeningBracket = atom.config.get('bracket-matcher.autocompleteBrackets') and @isOpeningBracket(text) and (not hasWordAfterCursor or hasClosingBracketAfterCursor) and not (@isQuote(text) and (hasWordBeforeCursor or hasQuoteBeforeCursor)) and not hasEscapeSequenceBeforeCursor
       pair = @pairedCharacters[text]
 
     skipOverExistingClosingBracket = false

--- a/lib/bracket-matcher.coffee
+++ b/lib/bracket-matcher.coffee
@@ -61,10 +61,10 @@ class BracketMatcher
     hasQuoteBeforeCursor = previousCharacter is text[0]
     hasEscapeSequenceBeforeCursor = previousCharacters.match(/\\/g)?.length >= 1 # To guard against the "\\" sequence
     hasClosingBracketAfterCursor = do (@pairsToIndent) ->
-        for op, cl of pairsToIndent
-            if cl is nextCharacter[0]
-                return true
-        return false
+      for op, cl of pairsToIndent
+        if cl is nextCharacter[0]
+          return true
+      return false
 
     if text is '#' and @isCursorOnInterpolatedString()
       autoCompleteOpeningBracket = atom.config.get('bracket-matcher.autocompleteBrackets') and not hasEscapeSequenceBeforeCursor

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -547,7 +547,15 @@ describe "bracket matching", ->
 
         expect(editor.buffer.getText()).toBe "())\na)b\n[)]\n1)2"
 
-    describe "when there is a non-word character after the cursor", ->
+    describe "when there is a non-whitespace character that isn't a closing bracket after the cursor", ->
+      it "does not insert a closing bracket after an opening bracket is inserted", ->
+        editor.buffer.setText('"')
+        editor.setCursorBufferPosition([0, 0])
+        editor.insertText '{'
+        expect(buffer.lineForRow(0)).toBe '{"'
+        expect(editor.getCursorBufferPosition()).toEqual([0, 1])
+
+    describe "when there is a closing bracket after the cursor", ->
       it "inserts a closing bracket after an opening bracket is inserted", ->
         editor.buffer.setText("}")
         editor.setCursorBufferPosition([0, 0])


### PR DESCRIPTION
This resolves #200.
A closing bracket is still inserted if the following character is also a closing bracket ')]}' or whitespace.
This is the same behavior as Sublime.

I also added a test to account for this change.
