### PR TITLE
Make updating matches faster for multi-cursor editing

### DIFF
--- a/lib/bracket-matcher-view.coffee
+++ b/lib/bracket-matcher-view.coffee
@@ -25,7 +25,7 @@ class BracketMatcherView
     @pairHighlighted = false
     @tagHighlighted = false
 
-    @subscriptions.add @editor.onDidChange =>
+    @subscriptions.add @editor.getBuffer().onDidChangeText =>
       @updateMatch()
 
     @subscriptions.add @editor.onDidChangeGrammar =>
@@ -55,8 +55,8 @@ class BracketMatcherView
     return unless cursor?
 
     cursorSubscriptions = new CompositeDisposable
-    cursorSubscriptions.add cursor.onDidChangePosition =>
-      @updateMatch()
+    cursorSubscriptions.add cursor.onDidChangePosition ({textChanged}) =>
+      @updateMatch() unless textChanged
 
     cursorSubscriptions.add cursor.onDidDestroy =>
       cursorSubscriptions.dispose()

--- a/lib/bracket-matcher-view.coffee
+++ b/lib/bracket-matcher-view.coffee
@@ -25,8 +25,13 @@ class BracketMatcherView
     @pairHighlighted = false
     @tagHighlighted = false
 
-    @subscriptions.add @editor.getBuffer().onDidChangeText =>
-      @updateMatch()
+    # TODO: remove conditional when `onDidChangeText` ships on stable.
+    if typeof @editor.getBuffer().onDidChangeText is "function"
+      @subscriptions.add @editor.getBuffer().onDidChangeText =>
+        @updateMatch()
+    else
+      @subscriptions.add @editor.onDidChange =>
+        @updateMatch()
 
     @subscriptions.add @editor.onDidChangeGrammar =>
       @updateMatch()


### PR DESCRIPTION
With this PR we make use of the new `TextBuffer.prototype.onDidChangeText` API and we also avoid to update bracket matches when the cursor moves because of a text change, because that scenario is already handled by the `onDidChangeText` event.

#### Before
![screen shot 2016-02-16 at 10 28 29](https://cloud.githubusercontent.com/assets/482957/13072329/ecae6988-d498-11e5-879d-002138b2bbc1.png)

_(Total: `~ 240ms`, benchmark performed by editing 500 lines, inserting 5 characters)_

#### After
![screen shot 2016-02-16 at 10 28 03](https://cloud.githubusercontent.com/assets/482957/13072355/1d1435da-d499-11e5-8534-e0f057ece1c1.png)

_(Total: `~ 4ms`, 60x faster)_

/cc: @nathansobo @maxbrunsfeld 