### PR TITLE
Allow scoped settings

### DIFF
--- a/lib/bracket-matcher.coffee
+++ b/lib/bracket-matcher.coffee
@@ -24,7 +24,6 @@ class BracketMatcher
     "‹": "›"
 
   toggleQuotes: (includeSmartQuotes) ->
-    return if @pairedCharacters? and includeSmartQuotes is (@pairedCharacters isnt @defaultPairs)
     if includeSmartQuotes
       @pairedCharacters = _.extend({}, @defaultPairs, @smartQuotePairs)
     else

--- a/lib/bracket-matcher.coffee
+++ b/lib/bracket-matcher.coffee
@@ -24,6 +24,7 @@ class BracketMatcher
     "‹": "›"
 
   toggleQuotes: (includeSmartQuotes) ->
+    return if @pairedCharacters? and includeSmartQuotes is (@pairedCharacters isnt @defaultPairs)
     if includeSmartQuotes
       @pairedCharacters = _.extend({}, @defaultPairs, @smartQuotePairs)
     else
@@ -40,14 +41,14 @@ class BracketMatcher
     @subscriptions.add atom.commands.add editorElement, 'bracket-matcher:remove-brackets-from-selection', (event) =>
       event.abortKeyBinding() unless @removeBrackets()
 
-    @subscriptions.add atom.config.observe 'bracket-matcher.autocompleteSmartQuotes', (newValue) =>
-      @toggleQuotes(newValue)
-
     @subscriptions.add @editor.onDidDestroy => @unsubscribe()
 
   insertText: (text, options) =>
     return true unless text
     return true if options?.select or options?.undo is 'skip'
+
+    @toggleQuotes(@getScopedSetting('bracket-matcher.autocompleteSmartQuotes'))
+
     return false if @wrapSelectionInBrackets(text)
     return true if @editor.hasMultipleCursors()
 
@@ -63,11 +64,11 @@ class BracketMatcher
     hasEscapeSequenceBeforeCursor = previousCharacters.match(/\\/g)?.length >= 1 # To guard against the "\\" sequence
 
     if text is '#' and @isCursorOnInterpolatedString()
-      autoCompleteOpeningBracket = atom.config.get('bracket-matcher.autocompleteBrackets') and not hasEscapeSequenceBeforeCursor
+      autoCompleteOpeningBracket = @getScopedSetting('bracket-matcher.autocompleteBrackets') and not hasEscapeSequenceBeforeCursor
       text += '{'
       pair = '}'
     else
-      autoCompleteOpeningBracket = atom.config.get('bracket-matcher.autocompleteBrackets') and @isOpeningBracket(text) and not hasWordAfterCursor and not (@isQuote(text) and (hasWordBeforeCursor or hasQuoteBeforeCursor)) and not hasEscapeSequenceBeforeCursor
+      autoCompleteOpeningBracket = @getScopedSetting('bracket-matcher.autocompleteBrackets') and @isOpeningBracket(text) and not hasWordAfterCursor and not (@isQuote(text) and (hasWordBeforeCursor or hasQuoteBeforeCursor)) and not hasEscapeSequenceBeforeCursor
       pair = @pairedCharacters[text]
 
     skipOverExistingClosingBracket = false
@@ -91,6 +92,8 @@ class BracketMatcher
     return if @editor.hasMultipleCursors()
     return unless @editor.getLastSelection().isEmpty()
 
+    @toggleQuotes(@getScopedSetting('bracket-matcher.autocompleteSmartQuotes'))
+
     cursorBufferPosition = @editor.getCursorBufferPosition()
     previousCharacters = @editor.getTextInBufferRange([cursorBufferPosition.traverse([0, -2]), cursorBufferPosition])
     nextCharacter = @editor.getTextInBufferRange([cursorBufferPosition, cursorBufferPosition.traverse([0, 1])])
@@ -102,7 +105,7 @@ class BracketMatcher
       @editor.transact =>
         @editor.insertText "\n\n"
         @editor.moveUp()
-        if atom.config.get('editor.autoIndent')
+        if @getScopedSetting('editor.autoIndent')
           cursorRow = @editor.getCursorBufferPosition().row
           @editor.autoIndentBufferRows(cursorRow, cursorRow + 1)
       false
@@ -111,6 +114,8 @@ class BracketMatcher
     return if @editor.hasMultipleCursors()
     return unless @editor.getLastSelection().isEmpty()
 
+    @toggleQuotes(@getScopedSetting('bracket-matcher.autocompleteSmartQuotes'))
+
     cursorBufferPosition = @editor.getCursorBufferPosition()
     previousCharacters = @editor.getTextInBufferRange([cursorBufferPosition.traverse([0, -2]), cursorBufferPosition])
     nextCharacter = @editor.getTextInBufferRange([cursorBufferPosition, cursorBufferPosition.traverse([0, 1])])
@@ -118,7 +123,7 @@ class BracketMatcher
     previousCharacter = previousCharacters.slice(-1)
 
     hasEscapeSequenceBeforeCursor = previousCharacters.match(/\\/g)?.length >= 1 # To guard against the "\\" sequence
-    if (@pairedCharacters[previousCharacter] is nextCharacter) and not hasEscapeSequenceBeforeCursor and atom.config.get('bracket-matcher.autocompleteBrackets')
+    if (@pairedCharacters[previousCharacter] is nextCharacter) and not hasEscapeSequenceBeforeCursor and @getScopedSetting('bracket-matcher.autocompleteBrackets')
       @editor.transact =>
         @editor.moveLeft()
         @editor.delete()
@@ -127,6 +132,7 @@ class BracketMatcher
 
   removeBrackets: ->
     bracketsRemoved = false
+    @toggleQuotes(@getScopedSetting('bracket-matcher.autocompleteSmartQuotes'))
     @editor.mutateSelectedText (selection) =>
       return unless @selectionIsWrappedByMatchingBrackets(selection)
 
@@ -145,7 +151,7 @@ class BracketMatcher
     bracketsRemoved
 
   wrapSelectionInBrackets: (bracket) ->
-    return false unless atom.config.get('bracket-matcher.wrapSelectionsInBrackets')
+    return false unless @getScopedSetting('bracket-matcher.wrapSelectionsInBrackets')
 
     if bracket is '#'
       return false unless @isCursorOnInterpolatedString()
@@ -218,3 +224,6 @@ class BracketMatcher
 
   unsubscribe: ->
     @subscriptions.dispose()
+
+  getScopedSetting: (key) ->
+    atom.config.get(key, scope: @editor.getLastCursor().getScopeDescriptor())

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -527,9 +527,19 @@ describe "bracket matching", ->
 
         expect(editor.buffer.getText()).toBe "a(b"
 
-    describe "when autocompleteBrackets configuration is disabled", ->
+    describe "when autocompleteBrackets configuration is disabled globally", ->
       it "does not insert a matching bracket", ->
         atom.config.set 'bracket-matcher.autocompleteBrackets', false
+        editor.buffer.setText("}")
+        editor.setCursorBufferPosition([0, 0])
+        editor.insertText '{'
+        expect(buffer.lineForRow(0)).toBe "{}"
+        expect(editor.getCursorBufferPosition()).toEqual([0, 1])
+
+    describe "when autocompleteBrackets configuration is disabled in scope", ->
+      it "does not insert a matching bracket", ->
+        atom.config.set 'bracket-matcher.autocompleteBrackets', true
+        atom.config.set 'bracket-matcher.autocompleteBrackets', false, scopeSelector: '.source.js'
         editor.buffer.setText("}")
         editor.setCursorBufferPosition([0, 0])
         editor.insertText '{'

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -666,9 +666,21 @@ describe "bracket matching", ->
         expect(editor.getSelectedBufferRange()).toEqual [[0, 1], [0, 5]]
         expect(editor.getLastSelection().isReversed()).toBeTruthy()
 
-      describe "when the bracket-matcher.wrapSelectionsInBrackets is falsy", ->
+      describe "when the bracket-matcher.wrapSelectionsInBrackets is falsy globally", ->
         it "does not wrap the selection in brackets", ->
           atom.config.set('bracket-matcher.wrapSelectionsInBrackets', false)
+          editor.setText 'text'
+          editor.moveToBottom()
+          editor.selectToTop()
+          editor.selectAll()
+          editor.insertText '('
+          expect(buffer.getText()).toBe '('
+          expect(editor.getSelectedBufferRange()).toEqual [[0, 1], [0, 1]]
+
+      describe "when the bracket-matcher.wrapSelectionsInBrackets is falsy in scope", ->
+        it "does not wrap the selection in brackets", ->
+          atom.config.set('bracket-matcher.wrapSelectionsInBrackets', true)
+          atom.config.set('bracket-matcher.wrapSelectionsInBrackets', false, scopeSelector: '.source.js')
           editor.setText 'text'
           editor.moveToBottom()
           editor.selectToTop()
@@ -921,8 +933,21 @@ describe "bracket matching", ->
       editor.backspace()
       expect(buffer.lineForRow(0)).toBe ""
 
-    it "does not delete end bracket even if it directly precedes a begin bracket if autocomplete is turned off", ->
+    it "does not delete end bracket even if it directly precedes a begin bracket if autocomplete is turned off globally", ->
       atom.config.set 'bracket-matcher.autocompleteBrackets', false
+      buffer.setText("")
+      editor.setCursorBufferPosition([0, 0])
+      editor.insertText "{"
+      expect(buffer.lineForRow(0)).toBe "{"
+      editor.insertText "}"
+      expect(buffer.lineForRow(0)).toBe "{}"
+      editor.setCursorBufferPosition([0, 1])
+      editor.backspace()
+      expect(buffer.lineForRow(0)).toBe "}"
+
+    it "does not delete end bracket even if it directly precedes a begin bracket if autocomplete is turned off in scope", ->
+      atom.config.set 'bracket-matcher.autocompleteBrackets', true
+      atom.config.set 'bracket-matcher.autocompleteBrackets', false, scopeSelector: '.source.js'
       buffer.setText("")
       editor.setCursorBufferPosition([0, 0])
       editor.insertText "{"


### PR DESCRIPTION
With scoped settings users are able to change bracket-matcher depending on the currently used scope:

```coffee
".lisp.source":
  "bracket-matcher":
    autocompleteBrackets: false
  editor:
    autoIndent: false
```

This is useful for languages like Lisp, that don't use `` ` `` and other characters for quotes.

It also fixes an (as far as I know) unreported bug where a scoped `editor.autoIndent` setting would be ignored.

Consider this a first step towards #182.