### PR TITLE
Include namespace prefixes in unclosed tags

### DIFF
--- a/lib/tag-finder.coffee
+++ b/lib/tag-finder.coffee
@@ -132,7 +132,7 @@ class TagFinder
   #
   # Returns a string with the name of the most recent unclosed tag.
   tagsNotClosedInFragment: (fragment) ->
-    @parseFragment fragment, [], /<(\w[-\w]*)|<\/(\w[-\w]*)/, -> true
+    @parseFragment fragment, [], /<(\w[-\w]*(?:\:\w[-\w]*)?)|<\/(\w[-\w]*(?:\:\w[-\w]*)?)/, -> true
 
   # Parses the given fragment of html code and returns true if the given tag
   # has a matching closing tag in it. If tag is reopened and reclosed in the

--- a/spec/close-tag-spec.coffee
+++ b/spec/close-tag-spec.coffee
@@ -26,10 +26,21 @@ describe 'closeTag', ->
       tags = tagFinder.tagsNotClosedInFragment(fragment)
       expect(tags).toEqual(['html', 'body', 'h1'])
 
+    # Is this desirable? It results in malformed XML for closing tag insertions.
+    it 'detects an incomplete tag', ->
+      fragment = '<html<body<h1'
+      tags = tagFinder.tagsNotClosedInFragment(fragment)
+      expect(tags).toEqual(['html', 'body', 'h1'])
+
     it 'is not confused by tag attributes', ->
       fragment = '<html><head></head><body class="c"><h1 class="p"><p></p>'
       tags = tagFinder.tagsNotClosedInFragment(fragment)
       expect(tags).toEqual(['html', 'body', 'h1'])
+
+    it 'is not confused by namespace prefixes', ->
+      fragment = '<xhtml:html><xhtml:body><xhtml:h1>'
+      tags = tagFinder.tagsNotClosedInFragment(fragment)
+      expect(tags).toEqual(['xhtml:html', 'xhtml:body', 'xhtml:h1'])
 
   describe 'TagFinder::tagDoesNotCloseInFragment', ->
     it 'returns true if the given tag is not closed in the given fragment', ->


### PR DESCRIPTION
Fixes issue where `<foo:bar>` was closed with `</foo>`