### PR TITLE
Customize matching pairs - add to or remove from the package defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,6 @@ Matching brackets and quotes are sensibly inserted for you. If you dislike this
 functionality, you can disable it from the Bracket Matcher section of the
 Settings view (<kbd>cmd-,</kbd>).
 
-#### Smart Quotes
-
-You can toggle whether English/French style quotation marks (`“”`, `‘’`, `«»`
-and `‹›`) are autocompleted via the *Autocomplete Smart Quotes*  setting in the
-settings view.
-
 #### Custom Pairs
 
 You can customize matching pairs in Bracket Matcher at any time. You can do so either Globally via the Settings view (<kbd>cmd-,</kbd>) or at the Scope level via `config.cson` (<kbd>cmd-shift-p</kbd> + "config"). Changes take effect immediately.

--- a/README.md
+++ b/README.md
@@ -27,11 +27,20 @@ Settings view (<kbd>cmd-,</kbd>).
 
 You can customize matching pairs in Bracket Matcher at any time. You can do so either Globally via the Settings view (<kbd>cmd-,</kbd>) or at the Scope level via `config.cson` (<kbd>cmd-shift-p</kbd> + "config"). Changes take effect immediately.
 
-* <b>Autocomplete Characters</b> - Comma-separated pairs which override the package defaults.
+* <b>Autocomplete Characters</b> - Comma-separated pairs that the editor will treat as brackets / quotes. Entries in this field override the package defaults.
   * ie: `<>, (), []`
 
+* <b>Pairs to Indent</b> - Comma-separated pairs that enhance the editor's Auto Indent feature. When used, the indent level is increased following the opening bracket and a newline.
+Example:
+```
+fn main() {
+    | <---- Cursor positioned at one indent level higher
+}
+```
+
 ###### config.cson
-In addition to Global configs, you are able to add scope-specific modifications to Atom in `config.cson`. This is especially useful for editor rule changes specific to each language. Example:
+In addition to Global configs, you are able to add scope-specific modifications to Atom in `config.cson`. This is especially useful for editor rule changes specific to each language. Scope specific configs override package defaults <i>and</i> global configs.
+Example:
 ```
 ".rust.source":
 "bracket-matcher":

--- a/README.md
+++ b/README.md
@@ -9,10 +9,6 @@ and HTML tags.
 Autocompletes `[]`, `()`, and `{}`, `""`, `''`, `“”`, `‘’`, `«»`, `‹›`, and
 backticks.
 
-You can toggle whether English/French style quotation marks (`“”`, `‘’`, `«»`
-and `‹›`) are autocompleted via the *Autocomplete Smart Quotes*  setting in the
-settings view.
-
 Use <kbd>ctrl-m</kbd> to jump to the bracket matching the one adjacent to the cursor.
 It jumps to the nearest enclosing bracket when there's no adjacent bracket,
 
@@ -20,6 +16,37 @@ Use <kbd>ctrl-cmd-m</kbd> to select all the text inside the current brackets.
 
 Use <kbd>alt-cmd-.</kbd> to close the current XML/HTML tag.
 
+---
+### Configuration
+
 Matching brackets and quotes are sensibly inserted for you. If you dislike this
 functionality, you can disable it from the Bracket Matcher section of the
 Settings view (<kbd>cmd-,</kbd>).
+
+#### Smart Quotes
+
+You can toggle whether English/French style quotation marks (`“”`, `‘’`, `«»`
+and `‹›`) are autocompleted via the *Autocomplete Smart Quotes*  setting in the
+settings view.
+
+#### Custom Pairs
+
+You can add or remove matching pairs from Bracket Matcher at any time. You can do so either Globally via the Settings view (<kbd>cmd-,</kbd>) or at the Scope level via `config.cson` (<kbd>cmd-shift-p</kbd> + "config"). Changes take effect immediately.
+
+* <b>Add Pairs</b> - Comma-separated pairs to append to package defaults.
+  * ie: `<:>, %:%, @:@`
+* <b>Exclude Pairs</b> - Comma-separated pairs to remove from package defaults.
+  * ie: `':', [:]`
+
+###### config.cson
+In addition to Global configs, you are able to add scope-specific modifications to Atom in `config.cson`. This is especially useful for editor rule changes specific to each language. Example:
+```
+".rust.source":
+  "bracket-matcher":
+    addPairs: [
+      "<:>"
+    ]
+    excludePairs: [
+      "':'"
+    ]
+```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can customize matching pairs in Bracket Matcher at any time. You can do so e
 * <b>Autocomplete Characters</b> - Comma-separated pairs that the editor will treat as brackets / quotes. Entries in this field override the package defaults.
   * ie: `<>, (), []`
 
-* <b>Pairs to Indent</b> - Comma-separated pairs that enhance the editor's Auto Indent feature. When used, the indent level is increased following the opening bracket and a newline.
+* <b>Pairs With Extra Newline</b> - Comma-separated pairs that enhance the editor's Auto Indent feature. When used, a newline is automatically added between the pair when enter is pressed between them. Note: This feature is meant to be used in combination with brackets defined for indentation by the active language mode (increaseIndentPattern / decreaseIndentPattern).
 Example:
 ```
 fn main() {

--- a/README.md
+++ b/README.md
@@ -31,22 +31,22 @@ settings view.
 
 #### Custom Pairs
 
-You can add or remove matching pairs from Bracket Matcher at any time. You can do so either Globally via the Settings view (<kbd>cmd-,</kbd>) or at the Scope level via `config.cson` (<kbd>cmd-shift-p</kbd> + "config"). Changes take effect immediately.
+You can customize matching pairs in Bracket Matcher at any time. You can do so either Globally via the Settings view (<kbd>cmd-,</kbd>) or at the Scope level via `config.cson` (<kbd>cmd-shift-p</kbd> + "config"). Changes take effect immediately.
 
-* <b>Add Pairs</b> - Comma-separated pairs to append to package defaults.
-  * ie: `<:>, %:%, @:@`
-* <b>Exclude Pairs</b> - Comma-separated pairs to remove from package defaults.
-  * ie: `':', [:]`
+* <b>Autocomplete Characters</b> - Comma-separated pairs which override the package defaults.
+  * ie: `<>, (), []`
 
 ###### config.cson
 In addition to Global configs, you are able to add scope-specific modifications to Atom in `config.cson`. This is especially useful for editor rule changes specific to each language. Example:
 ```
 ".rust.source":
-  "bracket-matcher":
-    addPairs: [
-      "<:>"
-    ]
-    excludePairs: [
-      "':'"
-    ]
+"bracket-matcher":
+  autocompleteCharacters: [
+    "()"
+    "[]"
+    "{}"
+    "<>"
+    "\"\""
+    "``"
+  ]
 ```

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 Highlights and jumps between `[]`, `()`, and `{}`. Also highlights matching XML
 and HTML tags.
 
-Autocompletes `[]`, `()`, and `{}`, `""`, `''`, `“”`, `‘’`, `«»`, `‹›`, and
-backticks.
+Autocompletes `[]`, `()`, `{}`, `""`, `''`, `“”`, `‘’`, `«»`, `‹›`, and
+backticks by default.
 
 Use <kbd>ctrl-m</kbd> to jump to the bracket matching the one adjacent to the cursor.
 It jumps to the nearest enclosing bracket when there's no adjacent bracket,
@@ -21,16 +21,16 @@ Use <kbd>alt-cmd-.</kbd> to close the current XML/HTML tag.
 
 Matching brackets and quotes are sensibly inserted for you. If you dislike this
 functionality, you can disable it from the Bracket Matcher section of the
-Settings view.
+Settings View.
 
 #### Custom Pairs
 
-You can customize matching pairs in Bracket Matcher at any time. You can do so either globally via the Settings View or at the scope level via `config.cson`. Changes take effect immediately.
+You can customize matching pairs in Bracket Matcher at any time. You can do so either globally via the Settings View or at the scope level via your `config.cson`. Changes take effect immediately.
 
 * **Autocomplete Characters** - Comma-separated pairs that the editor will treat as brackets / quotes. Entries in this field override the package defaults.
   * For example: `<>, (), []`
 
-* **Pairs With Extra Newline** - Comma-separated pairs that enhance the editor's auto indent feature. When used, a newline is automatically added between the pair when enter is pressed between them. Note: This feature is meant to be used in combination with brackets defined for indentation by the active language mode (`increaseIndentPattern` / `decreaseIndentPattern`).
+* **Pairs With Extra Newline** - Comma-separated pairs that enhance the editor's auto indent feature. When used, a newline is automatically added between the pair when enter is pressed between them. Note: This feature is meant to be used in combination with brackets defined for indentation by the active language package (`increaseIndentPattern` / `decreaseIndentPattern`).
 Example:
 ```
 fn main() {
@@ -38,8 +38,8 @@ fn main() {
 }
 ```
 
-###### config.cson
-In addition to the global settings, you are also able to add scope-specific modifications to Atom in `config.cson`. This is especially useful for editor rule changes specific to each language. Scope-specific settings override package defaults _and_ global settings.
+#### Scoped settings
+In addition to the global settings, you are also able to add scope-specific modifications to Atom in your `config.cson`. This is especially useful for editor rule changes specific to each language. Scope-specific settings override package defaults _and_ global settings.
 Example:
 ```cson
 ".rust.source":

--- a/README.md
+++ b/README.md
@@ -21,16 +21,16 @@ Use <kbd>alt-cmd-.</kbd> to close the current XML/HTML tag.
 
 Matching brackets and quotes are sensibly inserted for you. If you dislike this
 functionality, you can disable it from the Bracket Matcher section of the
-Settings view (<kbd>cmd-,</kbd>).
+Settings view.
 
 #### Custom Pairs
 
-You can customize matching pairs in Bracket Matcher at any time. You can do so either Globally via the Settings view (<kbd>cmd-,</kbd>) or at the Scope level via `config.cson` (<kbd>cmd-shift-p</kbd> + "config"). Changes take effect immediately.
+You can customize matching pairs in Bracket Matcher at any time. You can do so either globally via the Settings View or at the scope level via `config.cson`. Changes take effect immediately.
 
 * **Autocomplete Characters** - Comma-separated pairs that the editor will treat as brackets / quotes. Entries in this field override the package defaults.
-  * ie: `<>, (), []`
+  * For example: `<>, (), []`
 
-* **Pairs With Extra Newline** - Comma-separated pairs that enhance the editor's Auto Indent feature. When used, a newline is automatically added between the pair when enter is pressed between them. Note: This feature is meant to be used in combination with brackets defined for indentation by the active language mode (`increaseIndentPattern` / `decreaseIndentPattern`).
+* **Pairs With Extra Newline** - Comma-separated pairs that enhance the editor's auto indent feature. When used, a newline is automatically added between the pair when enter is pressed between them. Note: This feature is meant to be used in combination with brackets defined for indentation by the active language mode (`increaseIndentPattern` / `decreaseIndentPattern`).
 Example:
 ```
 fn main() {

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ Settings view (<kbd>cmd-,</kbd>).
 
 You can customize matching pairs in Bracket Matcher at any time. You can do so either Globally via the Settings view (<kbd>cmd-,</kbd>) or at the Scope level via `config.cson` (<kbd>cmd-shift-p</kbd> + "config"). Changes take effect immediately.
 
-* <b>Autocomplete Characters</b> - Comma-separated pairs that the editor will treat as brackets / quotes. Entries in this field override the package defaults.
+* **Autocomplete Characters** - Comma-separated pairs that the editor will treat as brackets / quotes. Entries in this field override the package defaults.
   * ie: `<>, (), []`
 
-* <b>Pairs With Extra Newline</b> - Comma-separated pairs that enhance the editor's Auto Indent feature. When used, a newline is automatically added between the pair when enter is pressed between them. Note: This feature is meant to be used in combination with brackets defined for indentation by the active language mode (increaseIndentPattern / decreaseIndentPattern).
+* **Pairs With Extra Newline** - Comma-separated pairs that enhance the editor's Auto Indent feature. When used, a newline is automatically added between the pair when enter is pressed between them. Note: This feature is meant to be used in combination with brackets defined for indentation by the active language mode (`increaseIndentPattern` / `decreaseIndentPattern`).
 Example:
 ```
 fn main() {
@@ -39,17 +39,17 @@ fn main() {
 ```
 
 ###### config.cson
-In addition to Global configs, you are able to add scope-specific modifications to Atom in `config.cson`. This is especially useful for editor rule changes specific to each language. Scope specific configs override package defaults <i>and</i> global configs.
+In addition to the global settings, you are also able to add scope-specific modifications to Atom in `config.cson`. This is especially useful for editor rule changes specific to each language. Scope-specific settings override package defaults _and_ global settings.
 Example:
-```
+```cson
 ".rust.source":
-"bracket-matcher":
-  autocompleteCharacters: [
-    "()"
-    "[]"
-    "{}"
-    "<>"
-    "\"\""
-    "``"
-  ]
+  "bracket-matcher":
+    autocompleteCharacters: [
+      "()"
+      "[]"
+      "{}"
+      "<>"
+      "\"\""
+      "``"
+    ]
 ```

--- a/lib/bracket-matcher-view.coffee
+++ b/lib/bracket-matcher-view.coffee
@@ -54,15 +54,15 @@ class BracketMatcherView
     @subscriptions.add @editor.onDidDestroy @destroy
 
     # Subscribe to config changes
-    @subscriptions.add atom.config.observe 'bracket-matcher.autocompleteBrackets', (updateBracketsConfig) =>
+    @subscriptions.add atom.config.observe 'bracket-matcher.autocompleteBrackets', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
       @updatePairs()
-    @subscriptions.add atom.config.observe 'bracket-matcher.autocompleteSmartQuotes', (updateBracketsConfig) =>
+    @subscriptions.add atom.config.observe 'bracket-matcher.autocompleteSmartQuotes', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
       @updatePairs()
-    @subscriptions.add atom.config.observe 'bracket-matcher.wrapSelectionsInBrackets', (updateBracketsConfig) =>
+    @subscriptions.add atom.config.observe 'bracket-matcher.wrapSelectionsInBrackets', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
       @updatePairs()
-    @subscriptions.add atom.config.observe 'bracket-matcher.excludePairs', (updateExcludePairs) =>
+    @subscriptions.add atom.config.observe 'bracket-matcher.excludePairs', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
       @updatePairs()
-    @subscriptions.add atom.config.observe 'bracket-matcher.addPairs', (updateAddPairs) =>
+    @subscriptions.add atom.config.observe 'bracket-matcher.addPairs', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
       @updatePairs()
 
     @updateMatch()
@@ -99,7 +99,7 @@ class BracketMatcherView
       @pairRegexes[startPair] = new RegExp("[#{_.escapeRegExp(startPair + endPair)}]", 'g')
 
   getScopedSetting: (key) ->
-    atom.config.get(key, scope: @editor.getLastCursor().getScopeDescriptor())
+    atom.config.get(key, scope: @editor.getRootScopeDescriptor())
 
   subscribeToCursor: ->
     cursor = @editor.getLastCursor()

--- a/lib/bracket-matcher-view.coffee
+++ b/lib/bracket-matcher-view.coffee
@@ -5,23 +5,11 @@ TagFinder = require './tag-finder'
 
 module.exports =
 class BracketMatcherView
-  startDefaultMatches:
-    '(': ')'
-    '[': ']'
-    '{': '}'
-
-  endDefaultMatches:
-    ')': '('
-    ']': '['
-    '}': '{'
-
-  constructor: (@editor, editorElement) ->
+  constructor: (@editor, editorElement, @matchManager) ->
     @subscriptions = new CompositeDisposable
     @tagFinder = new TagFinder(@editor)
     @pairHighlighted = false
     @tagHighlighted = false
-
-    @updatePairs()
 
     # TODO: remove conditional when `onDidChangeText` ships on stable.
     if typeof @editor.getBuffer().onDidChangeText is "function"
@@ -53,53 +41,10 @@ class BracketMatcherView
 
     @subscriptions.add @editor.onDidDestroy @destroy
 
-    # Subscribe to config changes
-    @subscriptions.add atom.config.observe 'bracket-matcher.autocompleteBrackets', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
-      @updatePairs()
-    @subscriptions.add atom.config.observe 'bracket-matcher.autocompleteSmartQuotes', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
-      @updatePairs()
-    @subscriptions.add atom.config.observe 'bracket-matcher.wrapSelectionsInBrackets', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
-      @updatePairs()
-    @subscriptions.add atom.config.observe 'bracket-matcher.excludePairs', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
-      @updatePairs()
-    @subscriptions.add atom.config.observe 'bracket-matcher.addPairs', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
-      @updatePairs()
-
     @updateMatch()
 
   destroy: =>
     @subscriptions.dispose()
-
-  excludePairs: (excludePairs) ->
-    if excludePairs.length
-      for excludePair in excludePairs
-        pairArray = excludePair.split ':'
-        @startPairMatches = _.omit(@startDefaultMatches, pairArray[0])
-        @endPairMatches = _.omit(@endDefaultMatches, pairArray[1])
-    else
-      @startPairMatches = @startDefaultMatches
-      @endPairMatches = @endDefaultMatches
-
-  addPairs: (addPairs) ->
-    if addPairs.length
-      for addPair in addPairs
-        pairArray = addPair.split ':'
-        newStartPair = {}
-        newStartPair[pairArray[0]] = pairArray[1]
-        @startPairMatches = _.extend(@startPairMatches, newStartPair)
-        newEndPair = {}
-        newEndPair[pairArray[1]] = pairArray[0]
-        @endPairMatches = _.extend(@endPairMatches, newEndPair)
-
-  updatePairs: ->
-    @pairRegexes = {}
-    @excludePairs(@getScopedSetting('bracket-matcher.excludePairs'))
-    @addPairs(@getScopedSetting('bracket-matcher.addPairs'))
-    for startPair, endPair of @startPairMatches
-      @pairRegexes[startPair] = new RegExp("[#{_.escapeRegExp(startPair + endPair)}]", 'g')
-
-  getScopedSetting: (key) ->
-    atom.config.get(key, scope: @editor.getRootScopeDescriptor())
 
   subscribeToCursor: ->
     cursor = @editor.getLastCursor()
@@ -125,11 +70,11 @@ class BracketMatcherView
     return unless @editor.getLastSelection().isEmpty()
     return if @editor.isFoldedAtCursorRow()
 
-    {position, currentPair, matchingPair} = @findCurrentPair(@startPairMatches)
+    {position, currentPair, matchingPair} = @findCurrentPair(@matchManager.pairedCharacters)
     if position
       matchPosition = @findMatchingEndPair(position, currentPair, matchingPair)
     else
-      {position, currentPair, matchingPair} = @findCurrentPair(@endPairMatches)
+      {position, currentPair, matchingPair} = @findCurrentPair(@matchManager.pairedCharactersInverse)
       if position
         matchPosition = @findMatchingStartPair(position, matchingPair, currentPair)
 
@@ -152,12 +97,12 @@ class BracketMatcherView
       text = @editor.getSelectedText()
 
       #check if the character to the left is part of a pair
-      if @startPairMatches.hasOwnProperty(text) or @endPairMatches.hasOwnProperty(text)
-        {position, currentPair, matchingPair} = @findCurrentPair(@startPairMatches)
+      if @matchManager.pairedCharacters.hasOwnProperty(text) or @matchManager.pairedCharactersInverse.hasOwnProperty(text)
+        {position, currentPair, matchingPair} = @findCurrentPair(@matchManager.pairedCharacters)
         if position
           matchPosition = @findMatchingEndPair(position, currentPair, matchingPair)
         else
-          {position, currentPair, matchingPair} = @findCurrentPair(@endPairMatches)
+          {position, currentPair, matchingPair} = @findCurrentPair(@matchManager.pairedCharactersInverse)
           if position
             matchPosition = @findMatchingStartPair(position, matchingPair, currentPair)
 
@@ -166,7 +111,7 @@ class BracketMatcherView
           @editor.delete()
           # if on the same line and the cursor is in front of an end pair
           # offset by one to make up for the missing character
-          if position.row is matchPosition.row and @endPairMatches.hasOwnProperty(currentPair)
+          if position.row is matchPosition.row and @matchManager.pairedCharactersInverse.hasOwnProperty(currentPair)
             position = position.traverse([0, -1])
           @editor.setCursorBufferPosition(position)
           @editor.delete()
@@ -179,7 +124,7 @@ class BracketMatcherView
     scanRange = new Range(startPairPosition.traverse([0, 1]), @editor.buffer.getEndPosition())
     endPairPosition = null
     unpairedCount = 0
-    @editor.scanInBufferRange @pairRegexes[startPair], scanRange, (result) ->
+    @editor.scanInBufferRange @matchManager.pairRegexes[startPair], scanRange, (result) ->
       switch result.match[0]
         when startPair
           unpairedCount++
@@ -195,7 +140,7 @@ class BracketMatcherView
     scanRange = new Range([0, 0], endPairPosition)
     startPairPosition = null
     unpairedCount = 0
-    @editor.backwardsScanInBufferRange @pairRegexes[startPair], scanRange, (result) ->
+    @editor.backwardsScanInBufferRange @matchManager.pairRegexes[startPair], scanRange, (result) ->
       switch result.match[0]
         when startPair
           unpairedCount--
@@ -208,8 +153,8 @@ class BracketMatcherView
 
   findAnyStartPair: (cursorPosition) ->
     scanRange = new Range([0, 0], cursorPosition)
-    startPair = _.escapeRegExp(_.keys(@startPairMatches).join(''))
-    endPair = _.escapeRegExp(_.keys(@endPairMatches).join(''))
+    startPair = _.escapeRegExp(_.keys(@matchManager.pairedCharacters).join(''))
+    endPair = _.escapeRegExp(_.keys(@matchManager.pairedCharactersInverse).join(''))
     combinedRegExp = new RegExp("[#{startPair}#{endPair}]", 'g')
     startPairRegExp = new RegExp("[#{startPair}]", 'g')
     endPairRegExp = new RegExp("[#{endPair}]", 'g')
@@ -309,7 +254,7 @@ class BracketMatcherView
     else
       if startPosition = @findAnyStartPair(@editor.getCursorBufferPosition())
         startPair = @editor.getTextInRange(Range.fromPointWithDelta(startPosition, 0, 1))
-        endPosition = @findMatchingEndPair(startPosition, startPair, @startPairMatches[startPair])
+        endPosition = @findMatchingEndPair(startPosition, startPair, @matchManager.pairedCharacters[startPair])
       else if pair = @tagFinder.findEnclosingTags()
         {startRange, endRange} = pair
         if startRange.compare(endRange) > 0

--- a/lib/bracket-matcher-view.coffee
+++ b/lib/bracket-matcher-view.coffee
@@ -91,7 +91,7 @@ class BracketMatcherView
         newEndPair[pairArray[1]] = pairArray[0]
         @endPairMatches = _.extend(@endPairMatches, newEndPair)
 
-  updatePairs: () ->
+  updatePairs: ->
     @pairRegexes = {}
     @excludePairs(@getScopedSetting('bracket-matcher.excludePairs'))
     @addPairs(@getScopedSetting('bracket-matcher.addPairs'))

--- a/lib/bracket-matcher.coffee
+++ b/lib/bracket-matcher.coffee
@@ -71,7 +71,7 @@ class BracketMatcher
     previousCharacter = previousCharacters.slice(-1)
 
     hasEscapeSequenceBeforeCursor = previousCharacters.match(/\\/g)?.length >= 1 # To guard against the "\\" sequence
-    if @matchManager.pairsToIndent[previousCharacter] is nextCharacter and not hasEscapeSequenceBeforeCursor
+    if @matchManager.pairsWithExtraNewline[previousCharacter] is nextCharacter and not hasEscapeSequenceBeforeCursor
       @editor.transact =>
         @editor.insertText "\n\n"
         @editor.moveUp()

--- a/lib/bracket-matcher.coffee
+++ b/lib/bracket-matcher.coffee
@@ -64,15 +64,15 @@ class BracketMatcher
     @subscriptions.add @editor.onDidDestroy => @unsubscribe()
 
     # Subscribe to config changes
-    @subscriptions.add atom.config.observe 'bracket-matcher.autocompleteBrackets', (updateBracketsConfig) =>
+    @subscriptions.add atom.config.observe 'bracket-matcher.autocompleteBrackets', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
       @updateConfig()
-    @subscriptions.add atom.config.observe 'bracket-matcher.autocompleteSmartQuotes', (updateBracketsConfig) =>
+    @subscriptions.add atom.config.observe 'bracket-matcher.autocompleteSmartQuotes', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
       @updateConfig()
-    @subscriptions.add atom.config.observe 'bracket-matcher.wrapSelectionsInBrackets', (updateBracketsConfig) =>
+    @subscriptions.add atom.config.observe 'bracket-matcher.wrapSelectionsInBrackets', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
       @updateConfig()
-    @subscriptions.add atom.config.observe 'bracket-matcher.excludePairs', (updateBracketsConfig) =>
+    @subscriptions.add atom.config.observe 'bracket-matcher.excludePairs', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
       @updateConfig()
-    @subscriptions.add atom.config.observe 'bracket-matcher.addPairs', (updateBracketsConfig) =>
+    @subscriptions.add atom.config.observe 'bracket-matcher.addPairs', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
       @updateConfig()
 
   insertText: (text, options) =>
@@ -251,4 +251,4 @@ class BracketMatcher
     @subscriptions.dispose()
 
   getScopedSetting: (key) ->
-    atom.config.get(key, scope: @editor.getLastCursor().getScopeDescriptor())
+    atom.config.get(key, scope: @editor.getRootScopeDescriptor())

--- a/lib/bracket-matcher.coffee
+++ b/lib/bracket-matcher.coffee
@@ -43,7 +43,7 @@ class BracketMatcher
         newPair[pairArray[0]] = pairArray[1]
         @pairedCharacters = _.extend(@pairedCharacters, newPair)
 
-  updateConfig: () ->
+  updateConfig: ->
     @toggleQuotes(@getScopedSetting('bracket-matcher.autocompleteSmartQuotes'))
     @excludePairs(@getScopedSetting('bracket-matcher.excludePairs'))
     @addPairs(@getScopedSetting('bracket-matcher.addPairs'))

--- a/lib/bracket-matcher.coffee
+++ b/lib/bracket-matcher.coffee
@@ -29,6 +29,25 @@ class BracketMatcher
     else
       @pairedCharacters = @defaultPairs
 
+  excludePairs: (excludePairs) ->
+    if excludePairs.length
+      for excludePair in excludePairs
+        pairArray = excludePair.split ':'
+        @pairedCharacters = _.omit(@pairedCharacters, pairArray[0])
+
+  addPairs: (addPairs) ->
+    if addPairs.length
+      for addPair in addPairs
+        pairArray = addPair.split ':'
+        newPair = {}
+        newPair[pairArray[0]] = pairArray[1]
+        @pairedCharacters = _.extend(@pairedCharacters, newPair)
+
+  applyConfig: () ->
+    @toggleQuotes(@getScopedSetting('bracket-matcher.autocompleteSmartQuotes'))
+    @excludePairs(@getScopedSetting('bracket-matcher.excludePairs'))
+    @addPairs(@getScopedSetting('bracket-matcher.addPairs'))
+
   constructor: (@editor, editorElement) ->
     @subscriptions = new CompositeDisposable
     @bracketMarkers = []
@@ -46,7 +65,7 @@ class BracketMatcher
     return true unless text
     return true if options?.select or options?.undo is 'skip'
 
-    @toggleQuotes(@getScopedSetting('bracket-matcher.autocompleteSmartQuotes'))
+    @applyConfig()
 
     return false if @wrapSelectionInBrackets(text)
     return true if @editor.hasMultipleCursors()
@@ -91,7 +110,7 @@ class BracketMatcher
     return if @editor.hasMultipleCursors()
     return unless @editor.getLastSelection().isEmpty()
 
-    @toggleQuotes(@getScopedSetting('bracket-matcher.autocompleteSmartQuotes'))
+    @applyConfig()
 
     cursorBufferPosition = @editor.getCursorBufferPosition()
     previousCharacters = @editor.getTextInBufferRange([cursorBufferPosition.traverse([0, -2]), cursorBufferPosition])
@@ -113,7 +132,7 @@ class BracketMatcher
     return if @editor.hasMultipleCursors()
     return unless @editor.getLastSelection().isEmpty()
 
-    @toggleQuotes(@getScopedSetting('bracket-matcher.autocompleteSmartQuotes'))
+    @applyConfig()
 
     cursorBufferPosition = @editor.getCursorBufferPosition()
     previousCharacters = @editor.getTextInBufferRange([cursorBufferPosition.traverse([0, -2]), cursorBufferPosition])
@@ -131,7 +150,7 @@ class BracketMatcher
 
   removeBrackets: ->
     bracketsRemoved = false
-    @toggleQuotes(@getScopedSetting('bracket-matcher.autocompleteSmartQuotes'))
+    @applyConfig()
     @editor.mutateSelectedText (selection) =>
       return unless @selectionIsWrappedByMatchingBrackets(selection)
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,3 +1,4 @@
+MatchManager = null
 BracketMatcherView = null
 BracketMatcher = null
 
@@ -6,8 +7,11 @@ module.exports =
     atom.workspace.observeTextEditors (editor) ->
       editorElement = atom.views.getView(editor)
 
+      MatchManager ?= require './match-manager'
+      matchManager = new MatchManager(editor, editorElement)
+
       BracketMatcherView ?= require './bracket-matcher-view'
-      new BracketMatcherView(editor, editorElement)
+      new BracketMatcherView(editor, editorElement, matchManager)
 
       BracketMatcher ?= require './bracket-matcher'
-      new BracketMatcher(editor, editorElement)
+      new BracketMatcher(editor, editorElement, matchManager)

--- a/lib/match-manager.coffee
+++ b/lib/match-manager.coffee
@@ -1,0 +1,60 @@
+_ = require 'underscore-plus'
+{CompositeDisposable} = require 'atom'
+
+module.exports =
+class MatchManager
+  smartQuotePairs:
+    "“": "”"
+    '‘': '’'
+    "«": "»"
+    "‹": "›"
+
+  appendPair: (pairList, [itemLeft, itemRight]) ->
+    newPair = {}
+    newPair[itemLeft] = itemRight
+    pairList = _.extend(pairList, newPair)
+
+  processAutoPairs: (autocompletePairs, pairedList, dataFun) ->
+    if autocompletePairs.length
+      for autocompletePair in autocompletePairs
+        pairArray = autocompletePair.split ''
+        @appendPair(pairedList, dataFun(pairArray))
+
+  toggleQuotes: (includeSmartQuotes) ->
+    if includeSmartQuotes
+      @pairedCharacters = _.extend(@pairedCharacters, @smartQuotePairs)
+
+  updateConfig: ->
+    @pairedCharacters = {}
+    @pairedCharactersInverse = {}
+    @pairRegexes = {}
+    @pairsToIndent = {}
+    @processAutoPairs(@getScopedSetting('bracket-matcher.autocompleteCharacters'), @pairedCharacters, ((x) -> return [x[0], x[1]]) )
+    @toggleQuotes(@getScopedSetting('bracket-matcher.autocompleteSmartQuotes'))
+    @processAutoPairs(@getScopedSetting('bracket-matcher.autocompleteCharacters'), @pairedCharactersInverse, ((x) -> return [x[1], x[0]]) )
+    @processAutoPairs(@getScopedSetting('bracket-matcher.pairsToIndent'), @pairsToIndent, ((x) -> return [x[0], x[1]]) )
+    for startPair, endPair of @pairedCharacters
+      @pairRegexes[startPair] = new RegExp("[#{_.escapeRegExp(startPair + endPair)}]", 'g')
+
+  getScopedSetting: (key) ->
+    atom.config.get(key, scope: @editor.getRootScopeDescriptor())
+
+  constructor: (@editor, editorElement) ->
+    @subscriptions = new CompositeDisposable
+
+    @updateConfig()
+
+    # Subscribe to config changes
+    @subscriptions.add atom.config.observe 'bracket-matcher.autocompleteBrackets', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
+      @updateConfig()
+    @subscriptions.add atom.config.observe 'bracket-matcher.autocompleteSmartQuotes', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
+      @updateConfig()
+    @subscriptions.add atom.config.observe 'bracket-matcher.wrapSelectionsInBrackets', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
+      @updateConfig()
+    @subscriptions.add atom.config.observe 'bracket-matcher.autocompleteCharacters', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
+      @updateConfig()
+    @subscriptions.add atom.config.observe 'bracket-matcher.pairsToIndent', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
+      @updateConfig()
+
+  destroy: =>
+    @subscriptions.dispose()

--- a/lib/match-manager.coffee
+++ b/lib/match-manager.coffee
@@ -34,10 +34,6 @@ class MatchManager
     @updateConfig()
 
     # Subscribe to config changes
-    @subscriptions.add atom.config.observe 'bracket-matcher.autocompleteBrackets', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
-      @updateConfig()
-    @subscriptions.add atom.config.observe 'bracket-matcher.wrapSelectionsInBrackets', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
-      @updateConfig()
     @subscriptions.add atom.config.observe 'bracket-matcher.autocompleteCharacters', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
       @updateConfig()
     @subscriptions.add atom.config.observe 'bracket-matcher.pairsWithExtraNewline', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>

--- a/lib/match-manager.coffee
+++ b/lib/match-manager.coffee
@@ -18,10 +18,10 @@ class MatchManager
     @pairedCharacters = {}
     @pairedCharactersInverse = {}
     @pairRegexes = {}
-    @pairsToIndent = {}
+    @pairsWithExtraNewline = {}
     @processAutoPairs(@getScopedSetting('bracket-matcher.autocompleteCharacters'), @pairedCharacters, ((x) -> return [x[0], x[1]]) )
     @processAutoPairs(@getScopedSetting('bracket-matcher.autocompleteCharacters'), @pairedCharactersInverse, ((x) -> return [x[1], x[0]]) )
-    @processAutoPairs(@getScopedSetting('bracket-matcher.pairsToIndent'), @pairsToIndent, ((x) -> return [x[0], x[1]]) )
+    @processAutoPairs(@getScopedSetting('bracket-matcher.pairsWithExtraNewline'), @pairsWithExtraNewline, ((x) -> return [x[0], x[1]]) )
     for startPair, endPair of @pairedCharacters
       @pairRegexes[startPair] = new RegExp("[#{_.escapeRegExp(startPair + endPair)}]", 'g')
 
@@ -40,7 +40,7 @@ class MatchManager
       @updateConfig()
     @subscriptions.add atom.config.observe 'bracket-matcher.autocompleteCharacters', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
       @updateConfig()
-    @subscriptions.add atom.config.observe 'bracket-matcher.pairsToIndent', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
+    @subscriptions.add atom.config.observe 'bracket-matcher.pairsWithExtraNewline', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
       @updateConfig()
 
   destroy: =>

--- a/lib/match-manager.coffee
+++ b/lib/match-manager.coffee
@@ -3,12 +3,6 @@ _ = require 'underscore-plus'
 
 module.exports =
 class MatchManager
-  smartQuotePairs:
-    "“": "”"
-    '‘': '’'
-    "«": "»"
-    "‹": "›"
-
   appendPair: (pairList, [itemLeft, itemRight]) ->
     newPair = {}
     newPair[itemLeft] = itemRight
@@ -20,17 +14,12 @@ class MatchManager
         pairArray = autocompletePair.split ''
         @appendPair(pairedList, dataFun(pairArray))
 
-  toggleQuotes: (includeSmartQuotes) ->
-    if includeSmartQuotes
-      @pairedCharacters = _.extend(@pairedCharacters, @smartQuotePairs)
-
   updateConfig: ->
     @pairedCharacters = {}
     @pairedCharactersInverse = {}
     @pairRegexes = {}
     @pairsToIndent = {}
     @processAutoPairs(@getScopedSetting('bracket-matcher.autocompleteCharacters'), @pairedCharacters, ((x) -> return [x[0], x[1]]) )
-    @toggleQuotes(@getScopedSetting('bracket-matcher.autocompleteSmartQuotes'))
     @processAutoPairs(@getScopedSetting('bracket-matcher.autocompleteCharacters'), @pairedCharactersInverse, ((x) -> return [x[1], x[0]]) )
     @processAutoPairs(@getScopedSetting('bracket-matcher.pairsToIndent'), @pairsToIndent, ((x) -> return [x[0], x[1]]) )
     for startPair, endPair of @pairedCharacters
@@ -46,8 +35,6 @@ class MatchManager
 
     # Subscribe to config changes
     @subscriptions.add atom.config.observe 'bracket-matcher.autocompleteBrackets', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
-      @updateConfig()
-    @subscriptions.add atom.config.observe 'bracket-matcher.autocompleteSmartQuotes', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
       @updateConfig()
     @subscriptions.add atom.config.observe 'bracket-matcher.wrapSelectionsInBrackets', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
       @updateConfig()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bracket-matcher",
-  "version": "0.82.2",
+  "version": "0.83.0",
   "main": "./lib/main",
   "description": "Highlight the matching bracket for the `(){}[]` character under the cursor. Move the cursor to the matching bracket with `ctrl-m`.",
   "repository": "https://github.com/atom/bracket-matcher",
@@ -16,6 +16,22 @@
     "coffeelint": "^1.9.7"
   },
   "configSchema": {
+    "excludePairs": {
+      "description": "Disable autocomplete of provided opening bracket and quote characters, such as `(`, and `\"`.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "string"
+      }
+    },
+    "addPairs": {
+      "description": "Add autocomplete of provided pair of characters, such as `(:)`, and `\":\"`.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "string"
+      }
+    },
     "autocompleteBrackets": {
       "type": "boolean",
       "default": true,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "autocompleteCharacters": {
       "description": "Autocompleted characters treated as matching pairs, such as `<>`, and `%%`.",
       "type": "array",
-      "default": ["()","[]","{}","\"\"","''","``"],
+      "default": ["()","[]","{}","\"\"","''","``","“”","‘’","«»","‹›"],
       "items": {
         "type": "string"
       }
@@ -36,11 +36,6 @@
       "type": "boolean",
       "default": true,
       "description": "Autocomplete bracket and quote characters, such as `(` and `)`, and `\"`."
-    },
-    "autocompleteSmartQuotes": {
-      "type": "boolean",
-      "default": true,
-      "description": "Autocomplete smart quote characters, such as `“` and `”`, and `«` and `»`."
     },
     "wrapSelectionsInBrackets": {
       "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
         "type": "string"
       }
     },
-    "pairsToIndent": {
-      "description": "Brackets for which to automatically increase indent level (ie: code blocks).",
+    "pairsWithExtraNewline": {
+      "description": "Automatically add a newline between the pair when enter is pressed.",
       "type": "array",
       "default": ["()","[]","{}"],
       "items": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "configSchema": {
     "autocompleteCharacters": {
-      "description": "Autocompleted characters treated as matching pairs, such as `<>`, and `%%`.",
+      "description": "Autocompleted characters treated as matching pairs, such as `()`, and `{}`.",
       "type": "array",
       "default": ["()","[]","{}","\"\"","''","``","“”","‘’","«»","‹›"],
       "items": {
@@ -25,7 +25,7 @@
       }
     },
     "pairsToIndent": {
-      "description": "Pairs that are automatically indented.",
+      "description": "Brackets for which to automatically increase indent level (ie: code blocks).",
       "type": "array",
       "default": ["()","[]","{}"],
       "items": {

--- a/package.json
+++ b/package.json
@@ -16,18 +16,18 @@
     "coffeelint": "^1.9.7"
   },
   "configSchema": {
-    "excludePairs": {
-      "description": "Disable autocomplete of provided pairs of bracket and quote characters, such as `(:)`, and `\":\"`.",
+    "autocompleteCharacters": {
+      "description": "Autocompleted characters treated as matching pairs, such as `<>`, and `%%`.",
       "type": "array",
-      "default": [],
+      "default": ["()","[]","{}","\"\"","''","``"],
       "items": {
         "type": "string"
       }
     },
-    "addPairs": {
-      "description": "Add autocomplete of provided pair of characters, such as `<:>`, and `%:%`.",
+    "pairsToIndent": {
+      "description": "Pairs that are automatically indented.",
       "type": "array",
-      "default": [],
+      "default": ["()","[]","{}"],
       "items": {
         "type": "string"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bracket-matcher",
-  "version": "0.83.0",
+  "version": "0.82.2",
   "main": "./lib/main",
   "description": "Highlight the matching bracket for the `(){}[]` character under the cursor. Move the cursor to the matching bracket with `ctrl-m`.",
   "repository": "https://github.com/atom/bracket-matcher",
@@ -17,7 +17,7 @@
   },
   "configSchema": {
     "excludePairs": {
-      "description": "Disable autocomplete of provided opening bracket and quote characters, such as `(`, and `\"`.",
+      "description": "Disable autocomplete of provided pairs of bracket and quote characters, such as `(:)`, and `\":\"`.",
       "type": "array",
       "default": [],
       "items": {
@@ -25,7 +25,7 @@
       }
     },
     "addPairs": {
-      "description": "Add autocomplete of provided pair of characters, such as `(:)`, and `\":\"`.",
+      "description": "Add autocomplete of provided pair of characters, such as `<:>`, and `%:%`.",
       "type": "array",
       "default": [],
       "items": {

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -117,7 +117,7 @@ describe "bracket matching", ->
         editor.setCursorBufferPosition([0, 0])
         expectHighlights([0, 0], [0, 4])
 
-        editor.setCursorBufferPosition([0, 4])
+        editor.setCursorBufferPosition([0, 5])
         expectHighlights([0, 4], [0, 0])
 
         editor.setCursorBufferPosition([0, 2])
@@ -127,7 +127,7 @@ describe "bracket matching", ->
         editor.setCursorBufferPosition([0, 0])
         expectHighlights([0, 0], [0, 4])
 
-        editor.setCursorBufferPosition([0, 4])
+        editor.setCursorBufferPosition([0, 5])
         expectHighlights([0, 4], [0, 0])
 
         editor.setCursorBufferPosition([0, 2])

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -544,42 +544,22 @@ describe "bracket matching", ->
         expect(buffer.lineForRow(0)).toBe "{}"
         expect(editor.getCursorBufferPosition()).toEqual([0, 1])
 
-    describe "when addPairs configuration is set globally", ->
-      it "inserts a matching carat", ->
-        atom.config.set 'bracket-matcher.addPairs', ['<:>']
+    describe "when autocompleteCharacters configuration is set globally", ->
+      it "inserts a matching angle bracket", ->
+        atom.config.set 'bracket-matcher.autocompleteCharacters', ['<>']
         editor.setCursorBufferPosition([0, 0])
         editor.insertText '<'
         expect(buffer.lineForRow(0)).toBe "<>"
         expect(editor.getCursorBufferPosition()).toEqual([0, 1])
 
     # Scope tests inexplicably fail
-    xdescribe "when addPairs configuration is set in scope", ->
-      it "inserts a matching carat", ->
-        atom.config.set 'bracket-matcher.addPairs', []
-        atom.config.set 'bracket-matcher.addPairs', ['<:>'], scopeSelector: '.source.js'
+    describe "when autocompleteCharacters configuration is set in scope", ->
+      xit "inserts a matching angle bracket", ->
+        atom.config.set 'bracket-matcher.autocompleteCharacters', []
+        atom.config.set 'bracket-matcher.autocompleteCharacters', ['<>'], scopeSelector: '.source.js'
         editor.setCursorBufferPosition([0, 0])
         editor.insertText '<'
         expect(buffer.lineForRow(0)).toBe "<>"
-        expect(editor.getCursorBufferPosition()).toEqual([0, 1])
-
-    describe "when excludePairs configuration is set globally", ->
-      it "does not insert a matching bracket", ->
-        atom.config.set 'bracket-matcher.excludePairs', ['{:}']
-        editor.buffer.setText("}")
-        editor.setCursorBufferPosition([0, 0])
-        editor.insertText '{'
-        expect(buffer.lineForRow(0)).toBe "{}"
-        expect(editor.getCursorBufferPosition()).toEqual([0, 1])
-
-    # Scope tests inexplicably fail
-    xdescribe "when excludePairs configuration is set in scope", ->
-      it "does not insert a matching bracket", ->
-        atom.config.set 'bracket-matcher.excludePairs', []
-        atom.config.set 'bracket-matcher.excludePairs', ['{:}'], scopeSelector: '.source.js'
-        editor.buffer.setText("}")
-        editor.setCursorBufferPosition([0, 0])
-        editor.insertText '{'
-        expect(buffer.lineForRow(0)).toBe "{}"
         expect(editor.getCursorBufferPosition()).toEqual([0, 1])
 
     describe "when there are multiple cursors", ->

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -5,9 +5,6 @@ describe "bracket matching", ->
     atom.config.set 'bracket-matcher.autocompleteBrackets', true
 
     waitsForPromise ->
-      atom.workspace.open('sample.js')
-
-    waitsForPromise ->
       atom.packages.activatePackage('bracket-matcher')
 
     waitsForPromise ->
@@ -15,6 +12,9 @@ describe "bracket matching", ->
 
     waitsForPromise ->
       atom.packages.activatePackage('language-xml')
+
+    waitsForPromise ->
+      atom.workspace.open('sample.js')
 
     runs ->
       editor = atom.workspace.getActiveTextEditor()
@@ -627,10 +627,8 @@ describe "bracket matching", ->
         expect(buffer.lineForRow(0)).toBe "<>"
         expect(editor.getCursorBufferPosition()).toEqual([0, 1])
 
-    # Scope tests inexplicably fail
     describe "when autocompleteCharacters configuration is set in scope", ->
-      xit "inserts a matching angle bracket", ->
-        atom.config.set 'bracket-matcher.autocompleteCharacters', []
+      it "inserts a matching angle bracket", ->
         atom.config.set 'bracket-matcher.autocompleteCharacters', ['<>'], scopeSelector: '.source.js'
         editor.setCursorBufferPosition([0, 0])
         editor.insertText '<'

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -544,6 +544,44 @@ describe "bracket matching", ->
         expect(buffer.lineForRow(0)).toBe "{}"
         expect(editor.getCursorBufferPosition()).toEqual([0, 1])
 
+    describe "when addPairs configuration is set globally", ->
+      it "inserts a matching carat", ->
+        atom.config.set 'bracket-matcher.addPairs', ['<:>']
+        editor.setCursorBufferPosition([0, 0])
+        editor.insertText '<'
+        expect(buffer.lineForRow(0)).toBe "<>"
+        expect(editor.getCursorBufferPosition()).toEqual([0, 1])
+
+    # Scope tests inexplicably fail
+    xdescribe "when addPairs configuration is set in scope", ->
+      it "inserts a matching carat", ->
+        atom.config.set 'bracket-matcher.addPairs', []
+        atom.config.set 'bracket-matcher.addPairs', ['<:>'], scopeSelector: '.source.js'
+        editor.setCursorBufferPosition([0, 0])
+        editor.insertText '<'
+        expect(buffer.lineForRow(0)).toBe "<>"
+        expect(editor.getCursorBufferPosition()).toEqual([0, 1])
+
+    describe "when excludePairs configuration is set globally", ->
+      it "does not insert a matching bracket", ->
+        atom.config.set 'bracket-matcher.excludePairs', ['{:}']
+        editor.buffer.setText("}")
+        editor.setCursorBufferPosition([0, 0])
+        editor.insertText '{'
+        expect(buffer.lineForRow(0)).toBe "{}"
+        expect(editor.getCursorBufferPosition()).toEqual([0, 1])
+
+    # Scope tests inexplicably fail
+    xdescribe "when excludePairs configuration is set in scope", ->
+      it "does not insert a matching bracket", ->
+        atom.config.set 'bracket-matcher.excludePairs', []
+        atom.config.set 'bracket-matcher.excludePairs', ['{:}'], scopeSelector: '.source.js'
+        editor.buffer.setText("}")
+        editor.setCursorBufferPosition([0, 0])
+        editor.insertText '{'
+        expect(buffer.lineForRow(0)).toBe "{}"
+        expect(editor.getCursorBufferPosition()).toEqual([0, 1])
+
     describe "when there are multiple cursors", ->
       it "inserts ) at each cursor", ->
         editor.buffer.setText("()\nab\n[]\n12")


### PR DESCRIPTION
This allows you to add or remove matching pairs from Bracket Matcher at any time. You can do so either Globally via the Settings view (<kbd>cmd-,</kbd>) or at the Scope level via `config.cson` (<kbd>cmd-shift-p</kbd> + "config"). Changes take effect immediately.

I got tired of fighting this while developing in Rust. Upon searching about it, I found numerous discussions about the need, and pinpointed two existing issues pertaining to this enhancement. Issue #214 requests the ability to choose which matching pairs to use. Issue #236 requests the ability to turn off the matching functionality for certain characters.

![screen shot 2016-09-24 at 7 47 37 am](https://cloud.githubusercontent.com/assets/219596/18808872/34029526-822b-11e6-9b79-b63d0c5b3442.png)
