### PR TITLE
Recognize self-closing tags

### DIFF
--- a/lib/tag-finder.coffee
+++ b/lib/tag-finder.coffee
@@ -8,14 +8,14 @@ SelfClosingTags = require './self-closing-tags'
 module.exports =
 class TagFinder
   constructor: (@editor) ->
-    @tagPattern = /(<(\/?))([^\s>]+)([\s>]|$)/
-    @wordRegex = /[^>\r\n]*/
+    @tagPattern = /(<(\/?))([^\/\s>]+)((?:[^\/>]|[^>](?!>))*)(\/?)(>)/
+    @wordRegex = /(?!$)[^>]*>/
     @tagSelector = SelectorCache.get('meta.tag | punctuation.definition.tag')
     @commentSelector = SelectorCache.get('comment.*')
 
   patternForTagName: (tagName) ->
     tagName = _.escapeRegExp(tagName)
-    new RegExp("(<#{tagName}([\\s>]|$))|(</#{tagName}>)", 'gi')
+    new RegExp("(<#{tagName}((?:[^\/>]|[^>](?!>))*)(>))|(<\/#{tagName}>)", 'gi')
 
   isRangeCommented: (range) ->
     scopes = @editor.scopeDescriptorForBufferPosition(range.start).getScopesArray()
@@ -39,7 +39,10 @@ class TagFinder
       if match[1]
         unpairedCount--
         if unpairedCount < 0
-          startRange = range.translate([0, 1], [0, -match[2].length]) # Subtract < and tag name suffix from range
+          startRange = range.translate([0, 1], [0, -(match[2].length + match[3].length)]) # Subtract < and tag name suffix from range
+          until startRange.end.column > 0 # if the tag spans multiple lines, the end.column is negative, so iterate until it's not.
+            startRange.end.row -= 1 # move the end up one row
+            startRange.end.column = @editor.getBuffer().lineLengthForRow(startRange.end.row) + startRange.end.column + 2 # and set the column
           stop()
       else
         unpairedCount++
@@ -70,17 +73,20 @@ class TagFinder
     @editor.backwardsScanInBufferRange @tagPattern, [[0, 0], endPosition], ({match, range, stop}) =>
       stop()
 
-      [entireMatch, prefix, isClosingTag, tagName, suffix] = match
+      [entireMatch, prefix, isClosingTag, tagName, attributes, isSelfClosingTag, suffix] = match
 
       if range.start.row is range.end.row
-        startRange = range.translate([0, prefix.length], [0, -suffix.length])
+        startRange = range.translate([0, prefix.length], [0, -(attributes.length + isSelfClosingTag.length + suffix.length)])
       else
-        startRange = Range.fromObject([range.start.translate([0, prefix.length]), [range.start.row, Infinity]])
+        startRange = Range.fromObject([range.start.translate([0, prefix.length]), [range.start.row, tagName.length+1]])
 
       if isClosingTag
         endRange = @findStartTag(tagName, startRange.start)
       else
         endRange = @findEndTag(tagName, startRange.end)
+
+      if isSelfClosingTag
+        endRange = startRange
 
       ranges = {startRange, endRange} if startRange? and endRange?
     ranges
@@ -88,6 +94,10 @@ class TagFinder
   findEnclosingTags: ->
     if ranges = @findStartEndTags()
       if @isTagRange(ranges.startRange) and @isTagRange(ranges.endRange)
+        if ranges.startRange.start.row > ranges.endRange.start.row # if the endRange occurs after the startRange in the buffer, switch them
+          tempRange = ranges.startRange
+          ranges.startRange = ranges.endRange
+          ranges.endRange = tempRange
         return ranges
 
     null

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -5,6 +5,9 @@ describe "bracket matching", ->
     atom.config.set 'bracket-matcher.autocompleteBrackets', true
 
     waitsForPromise ->
+      atom.workspace.open('sample.js')
+
+    waitsForPromise ->
       atom.packages.activatePackage('bracket-matcher')
 
     waitsForPromise ->
@@ -12,9 +15,6 @@ describe "bracket matching", ->
 
     waitsForPromise ->
       atom.packages.activatePackage('language-xml')
-
-    waitsForPromise ->
-      atom.workspace.open('sample.js')
 
     runs ->
       editor = atom.workspace.getActiveTextEditor()
@@ -117,7 +117,7 @@ describe "bracket matching", ->
         editor.setCursorBufferPosition([0, 0])
         expectHighlights([0, 0], [0, 4])
 
-        editor.setCursorBufferPosition([0, 5])
+        editor.setCursorBufferPosition([0, 4])
         expectHighlights([0, 4], [0, 0])
 
         editor.setCursorBufferPosition([0, 2])
@@ -127,7 +127,7 @@ describe "bracket matching", ->
         editor.setCursorBufferPosition([0, 0])
         expectHighlights([0, 0], [0, 4])
 
-        editor.setCursorBufferPosition([0, 5])
+        editor.setCursorBufferPosition([0, 4])
         expectHighlights([0, 4], [0, 0])
 
         editor.setCursorBufferPosition([0, 2])
@@ -143,12 +143,6 @@ describe "bracket matching", ->
         expectHighlights([0, 6], [0, 0])
 
         editor.setCursorBufferPosition([0, 3])
-        expectNoHighlights()
-
-    describe "when the start character and end character of the pair are equivalent", ->
-      it "does not attempt to highlight pairs", ->
-        editor.setText "'hello'"
-        editor.setCursorBufferPosition([0, 0])
         expectNoHighlights()
 
     describe "when the cursor is moved off a pair", ->
@@ -677,22 +671,6 @@ describe "bracket matching", ->
         editor.setCursorBufferPosition([0, 0])
         editor.insertText '{'
         expect(buffer.lineForRow(0)).toBe "{}"
-        expect(editor.getCursorBufferPosition()).toEqual([0, 1])
-
-    describe "when autocompleteCharacters configuration is set globally", ->
-      it "inserts a matching angle bracket", ->
-        atom.config.set 'bracket-matcher.autocompleteCharacters', ['<>']
-        editor.setCursorBufferPosition([0, 0])
-        editor.insertText '<'
-        expect(buffer.lineForRow(0)).toBe "<>"
-        expect(editor.getCursorBufferPosition()).toEqual([0, 1])
-
-    describe "when autocompleteCharacters configuration is set in scope", ->
-      it "inserts a matching angle bracket", ->
-        atom.config.set 'bracket-matcher.autocompleteCharacters', ['<>'], scopeSelector: '.source.js'
-        editor.setCursorBufferPosition([0, 0])
-        editor.insertText '<'
-        expect(buffer.lineForRow(0)).toBe "<>"
         expect(editor.getCursorBufferPosition()).toEqual([0, 1])
 
     describe "when there are multiple cursors", ->


### PR DESCRIPTION
So I've been taking a look at issue #203 and I've fixed the issue of self-closing tags getting matched improperly.

I've modified the regular expressions throughout the `tag-finder` script to properly match tags based on the additional criterion of self-closing. I've also updated the `startRange` and `endRange` calculations accordingly. See below for an explanation of the issue and its side-effect.

-----

the bracketmatcher thinks that self-closing tags are actually opening tags and matches them with the next closing tag it can find as illustrated below:
<img height="64px" src="https://cloud.githubusercontent.com/assets/2711898/20320492/01c582b0-ab40-11e6-9747-886a44e02758.png" alt="test_space"/>

Interestingly enough, it doesn't do this if you write the tag without a space between the tag name and the closing bit:
<img height="64px" src="https://cloud.githubusercontent.com/assets/2711898/20320484/fb872930-ab3f-11e6-90a8-acb56bf47ebf.png" alt="test_nospace"/>

Problematically, it doesn't actually recognize the tag as a self-closing tag, but rather thinks that the tag name is "TEST/", and subsequently can't find a matching closing tag. This leads to the very interesting phenomenon shown below:
<img height="64px" src="https://cloud.githubusercontent.com/assets/2711898/20320823/3bf1846a-ab41-11e6-8129-f522fae942fc.png" alt="test_nospace_endtag"/>

This problem is caused by the `tag-finder.coffee` script and its method of identifying tags:

```coffeescript
/(<(\/?))([^\s>]+)([\s>]|$)/
```

The above regex matches tags by finding the prefix `<`, with the optional modifier of `/` to make it a closing tag, then isolates the tag name by matching anything that isn't a closing angle bracket or whitespace`[^\s>]+`, then matches either a whitespace, a closing angle bracket, OR the EOL `[\s>]|$`. The problem with this is that it doesn't actually check all the way to the end of the tag to see if it closes itself, leading to the assumption that any tag that any whitespace after the tagname means the tag is an opening tag.