### PR TITLE
Fixes reverse brace/bracket matching

### DIFF
--- a/lib/bracket-matcher-view.coffee
+++ b/lib/bracket-matcher-view.coffee
@@ -54,11 +54,11 @@ class BracketMatcherView
     return if @editor.isFoldedAtCursorRow()
     return if @isCursorOnCommentOrString()
 
-    {position, currentPair, matchingPair} = @findCurrentPair(@matchManager.pairedCharacters)
+    {position, currentPair, matchingPair} = @findCurrentPair(false)
     if position
       matchPosition = @findMatchingEndPair(position, currentPair, matchingPair)
     else
-      {position, currentPair, matchingPair} = @findCurrentPair(@matchManager.pairedCharactersInverse)
+      {position, currentPair, matchingPair} = @findCurrentPair(true)
       if position
         matchPosition = @findMatchingStartPair(position, matchingPair, currentPair)
 
@@ -82,11 +82,11 @@ class BracketMatcherView
 
       #check if the character to the left is part of a pair
       if @matchManager.pairedCharacters.hasOwnProperty(text) or @matchManager.pairedCharactersInverse.hasOwnProperty(text)
-        {position, currentPair, matchingPair} = @findCurrentPair(@matchManager.pairedCharacters)
+        {position, currentPair, matchingPair} = @findCurrentPair(false)
         if position
           matchPosition = @findMatchingEndPair(position, currentPair, matchingPair)
         else
-          {position, currentPair, matchingPair} = @findCurrentPair(@matchManager.pairedCharactersInverse)
+          {position, currentPair, matchingPair} = @findCurrentPair(true)
           if position
             matchPosition = @findMatchingStartPair(position, matchingPair, currentPair)
 
@@ -162,11 +162,19 @@ class BracketMatcherView
     @editor.decorateMarker(marker, type: 'highlight', class: 'bracket-matcher', deprecatedRegionClass: 'bracket-matcher')
     marker
 
-  findCurrentPair: (matches) ->
+  findCurrentPair: (isInverse) ->
     position = @editor.getCursorBufferPosition()
+    if isInverse
+      matches = @matchManager.pairedCharactersInverse
+      position = position.traverse([0, -1])
+    else
+      matches = @matchManager.pairedCharacters
     currentPair = @editor.getTextInRange(Range.fromPointWithDelta(position, 0, 1))
     unless matches[currentPair]
-      position = position.traverse([0, -1])
+      if isInverse
+        position = position.traverse([0, 1])
+      else
+        position = position.traverse([0, -1])
       currentPair = @editor.getTextInRange(Range.fromPointWithDelta(position, 0, 1))
     if matchingPair = matches[currentPair]
       {position, currentPair, matchingPair}

--- a/lib/bracket-matcher-view.coffee
+++ b/lib/bracket-matcher-view.coffee
@@ -79,6 +79,7 @@ class BracketMatcherView
     @editor.transact =>
       @editor.selectLeft() if @editor.getLastSelection().isEmpty()
       text = @editor.getSelectedText()
+      @editor.moveRight()
 
       #check if the character to the left is part of a pair
       if @matchManager.pairedCharacters.hasOwnProperty(text) or @matchManager.pairedCharactersInverse.hasOwnProperty(text)

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -77,6 +77,9 @@ describe "bracket matching", ->
         expectHighlights([0, 0], [0, 1])
 
         editor.setCursorBufferPosition([0, 2])
+        expectHighlights([0, 1], [0, 0])
+
+        editor.setCursorBufferPosition([0, 3])
         expectNoHighlights()
 
     describe "when there are commented brackets", ->

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -51,6 +51,25 @@ describe "bracket matching", ->
         editor.moveLeft()
         expectHighlights([12, 0], [0, 28])
 
+    describe "when closing multiple pairs", ->
+      it "always highlights the inner pair", ->
+        editor.setCursorBufferPosition([8, 53])
+        expectHighlights([8, 53], [8, 47])
+        editor.moveRight()
+        expectHighlights([8, 53], [8, 47])
+        editor.moveRight()
+        expectHighlights([8, 54], [8, 42])
+
+    describe "when opening multiple pairs", ->
+      it "always highlights the inner pair", ->
+        editor.setText '((1 + 1) * 2)'
+        editor.setCursorBufferPosition([0, 0])
+        expectHighlights([0, 0], [0, 12])
+        editor.moveRight()
+        expectHighlights([0, 1], [0, 7])
+        editor.moveRight()
+        expectHighlights([0, 1], [0, 7])
+
     describe "when the cursor is after an ending pair", ->
       it "highlights the starting pair and ending pair", ->
         editor.moveToBottom()


### PR DESCRIPTION
Fixes #116

Before | After
------------ | -------------
![screen shot 2016-12-12 at 1 04 06 am](https://cloud.githubusercontent.com/assets/1545444/21089636/c9bf6124-c007-11e6-8ddf-7807be07acc9.png) Cursor before closing bracket | ![screen shot 2016-12-12 at 1 04 24 am](https://cloud.githubusercontent.com/assets/1545444/21089647/db5ceed8-c007-11e6-927e-4c3535b77765.png) Behavior is unchanged
![screen shot 2016-12-12 at 1 13 20 am](https://cloud.githubusercontent.com/assets/1545444/21089705/4ba33ae4-c008-11e6-84b5-6000b075dc2a.png) Cursor after closing bracket | ![screen shot 2016-12-12 at 1 04 56 am](https://cloud.githubusercontent.com/assets/1545444/21089661/f6cd11b6-c007-11e6-9248-562d32cbcf7b.png) Highlights inner set of brackets
