### PR TITLE
Improve performance in large files

### DIFF
--- a/lib/bracket-matcher-view.coffee
+++ b/lib/bracket-matcher-view.coffee
@@ -1,8 +1,10 @@
 {CompositeDisposable} = require 'atom'
 _ = require 'underscore-plus'
-{Range} = require 'atom'
+{Range, Point} = require 'atom'
 TagFinder = require './tag-finder'
 SelectorCache = require './selector-cache'
+
+MAX_ROWS_TO_SCAN = 10000
 
 module.exports =
 class BracketMatcherView
@@ -105,7 +107,7 @@ class BracketMatcherView
         @editor.backspace()
 
   findMatchingEndPair: (startPairPosition, startPair, endPair) ->
-    scanRange = new Range(startPairPosition.traverse([0, 1]), @editor.buffer.getEndPosition())
+    scanRange = new Range(startPairPosition.traverse([0, 1]), startPairPosition.traverse([MAX_ROWS_TO_SCAN, 0]))
     endPairPosition = null
     unpairedCount = 0
     @editor.scanInBufferRange @matchManager.pairRegexes[startPair], scanRange, (result) =>
@@ -122,7 +124,7 @@ class BracketMatcherView
     endPairPosition
 
   findMatchingStartPair: (endPairPosition, startPair, endPair) ->
-    scanRange = new Range([0, 0], endPairPosition)
+    scanRange = new Range(endPairPosition.traverse([-MAX_ROWS_TO_SCAN, 0]), endPairPosition)
     startPairPosition = null
     unpairedCount = 0
     @editor.backwardsScanInBufferRange @matchManager.pairRegexes[startPair], scanRange, (result) =>

--- a/lib/bracket-matcher-view.coffee
+++ b/lib/bracket-matcher-view.coffee
@@ -107,6 +107,8 @@ class BracketMatcherView
         @editor.backspace()
 
   findMatchingEndPair: (startPairPosition, startPair, endPair) ->
+    return if startPair is endPair
+
     scanRange = new Range(startPairPosition.traverse([0, 1]), startPairPosition.traverse([MAX_ROWS_TO_SCAN, 0]))
     endPairPosition = null
     unpairedCount = 0
@@ -124,6 +126,8 @@ class BracketMatcherView
     endPairPosition
 
   findMatchingStartPair: (endPairPosition, startPair, endPair) ->
+    return if startPair is endPair
+
     scanRange = new Range(endPairPosition.traverse([-MAX_ROWS_TO_SCAN, 0]), endPairPosition)
     startPairPosition = null
     unpairedCount = 0

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -145,6 +145,12 @@ describe "bracket matching", ->
         editor.setCursorBufferPosition([0, 3])
         expectNoHighlights()
 
+    describe "when the start character and end character of the pair are equivalent", ->
+      it "does not attempt to highlight pairs", ->
+        editor.setText "'hello'"
+        editor.setCursorBufferPosition([0, 0])
+        expectNoHighlights()
+
     describe "when the cursor is moved off a pair", ->
       it "removes the starting pair and ending pair highlights", ->
         editor.moveToEndOfLine()


### PR DESCRIPTION
This PR massively reduces this package's negative impact on large file editing by adding some limitations.


### Remove support for identical open/close characters

First, we remove all identical pairs from the default settings, including `"` `'` and ``` ` ``` . Because the package can't determine whether a given character is the start or end of a pair by inspecting the character alone, it ends up assuming the next character it finds is a start pair and ends up scanning through the entire file. Proper implementation would require determining how many instances of the given character proceed the first match. If an odd number do, we could consider it a close bracket, otherwise an open bracket. Adding a scan from the beginning to cover this case didn't seem worth it to me in the short run since this feature wasn't really working anyway. We could have confined the scan to a single line for many languages, but that doesn't really generalize very well. I'm also worried about getting confused with constructs like `"""` in Python and CoffeeScript. Ultimately, I think we should revisit this whole package when we have better parse tree support someday so we can do a better job. For now I'm removing support for identical match pairs entirely.

### Limit scan to 10k lines

We do a fair amount of work on each match we encounter, mostly related to determining whether the matched range is inside a comment or a string. This ended up really killing us on unmatched brackets at the beginning or end of really huge files, because we'd scan the entire file when the cursor was placed on the bracket. There may be some optimization to do in the scope matching, but nothing super easy. For now I'm limiting the scan length to 10k lines. Beyond that you won't get matching bracket behavior. That seems reasonable to me.

Here's a profile of moving the cursor to an unmatched bracket at the beginning of a 250,000-line file...

Before this change, we block for 350ms:

![screen shot 2016-12-21 at 5 28 40 pm](https://cloud.githubusercontent.com/assets/1789/21411149/62a991c8-c7a3-11e6-96ea-7bbecc115a2c.png)

After limiting the scan to 10k lines, we block for 17ms. Not perfect, but at least sane.

![screen shot 2016-12-21 at 5 29 59 pm](https://cloud.githubusercontent.com/assets/1789/21411155/70044c3c-c7a3-11e6-94d2-1b03d272cc15.png)

/cc @maxbrunsfeld