### PR TITLE
Fix .travis.yml to build without objective-c work-around.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,14 @@
-language: objective-c
+language: generic
+
+env:
+  - CXX=g++-4.8
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
 
 notifications:
   email:


### PR DESCRIPTION
Atom's Travis configs set language to objective-c in order to use OS X's outdated C toolchain. Build errors occur during the build of node-gyp. Those are all due to the fact that it is expecting a C++11 compiler. Forcing Travis to use the right version, and making it add the proper toolchain, fixes this.

### Description of the Change

Change build language to `generic` and add C++11 toolchain.

Atom's Travis configs set language to objective-c in order to use OS X's outdated C toolchain. Build errors occur during the build of node-gyp. Those are all due to the fact that it is expecting a C++11 compiler. Forcing Travis to use the right version, and making it add the proper toolchain, fixes this.

### Alternate Designs

None. This is the appropriate solution for a build for Node.

### Benefits

Huge speed-up of Travis tests. Current tests can take > 1 hour to wait for an OS X build platform. With these settings changes, total build time is less than 1 minute.

### Possible Drawbacks

None.

### Applicable Issues

None known.