### PR TITLE
Fix tag-finder for self-closing tags xml tags (<foo/>)

### DIFF
--- a/lib/tag-finder.coffee
+++ b/lib/tag-finder.coffee
@@ -132,7 +132,7 @@ class TagFinder
   #
   # Returns a string with the name of the most recent unclosed tag.
   tagsNotClosedInFragment: (fragment) ->
-    @parseFragment fragment, [], /<(\w[-\w]*(?:\:\w[-\w]*)?)|<\/(\w[-\w]*(?:\:\w[-\w]*)?)/, -> true
+    @parseFragment fragment, [], /<(\w[-\w]*(?:\:\w[-\w]*)?)(?![^>]*\/>)|<\/(\w[-\w]*(?:\:\w[-\w]*)?)/, -> true
 
   # Parses the given fragment of html code and returns true if the given tag
   # has a matching closing tag in it. If tag is reopened and reclosed in the
@@ -145,7 +145,7 @@ class TagFinder
     stackLength = stack.length
     tag = tags[tags.length-1]
     escapedTag = _.escapeRegExp(tag)
-    matchExpr = new RegExp("<(#{escapedTag})|<\/(#{escapedTag})")
+    matchExpr = new RegExp("<(#{escapedTag})(?![^>]*\/>)|<\/(#{escapedTag})")
     stack = @parseFragment fragment, stack, matchExpr, (s) ->
       s.length >= stackLength or s[s.length-1] is tag
 

--- a/lib/tag-finder.coffee
+++ b/lib/tag-finder.coffee
@@ -143,7 +143,8 @@ class TagFinder
   #
   # fragment - a string containing a fragment of html code.
   #
-  # Returns a string with the name of the most recent unclosed tag.
+  # Returns an array of strings. Each string is a tag that is still to be closed
+  # (the most recent non closed tag is at the end of the array).
   tagsNotClosedInFragment: (fragment) ->
     @parseFragment fragment, [], tagStartOrEndRegex, -> true
 

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -1113,3 +1113,25 @@ describe "bracket matching", ->
       atom.commands.dispatch(editorElement, 'bracket-matcher:close-tag')
 
       expect(editor.getCursorBufferPosition()).toEqual [13, 16]
+
+    it 'does not get confused in case of self closing tags', ->
+      waitsForPromise ->
+        atom.workspace.open('sample.xml')
+
+      runs ->
+        editor = atom.workspace.getActiveTextEditor()
+        editorElement = atom.views.getView(editor)
+        {buffer} = editor
+
+        buffer.setText """
+          <bar name="test">
+            <foo value="15"/>
+
+        """
+
+        editor.setCursorBufferPosition([3, 1])
+        atom.commands.dispatch(editorElement, 'bracket-matcher:close-tag')
+
+        expect(editor.getCursorBufferPosition().row).toEqual 2
+        expect(editor.getCursorBufferPosition().column).toEqual 6
+        expect(editor.getTextInRange([[2, 0], [2, 6]])).toEqual '</bar>'

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -1114,24 +1114,105 @@ describe "bracket matching", ->
 
       expect(editor.getCursorBufferPosition()).toEqual [13, 16]
 
-    it 'does not get confused in case of self closing tags', ->
+    it 'does not get confused in case of nested self closing tags', ->
       waitsForPromise ->
         atom.workspace.open('sample.xml')
 
       runs ->
         editor = atom.workspace.getActiveTextEditor()
         editorElement = atom.views.getView(editor)
-        {buffer} = editor
 
-        buffer.setText """
+        editor.setText """
           <bar name="test">
             <foo value="15"/>
 
         """
 
-        editor.setCursorBufferPosition([3, 1])
+        editor.setCursorBufferPosition([2, 0])
         atom.commands.dispatch(editorElement, 'bracket-matcher:close-tag')
 
         expect(editor.getCursorBufferPosition().row).toEqual 2
         expect(editor.getCursorBufferPosition().column).toEqual 6
         expect(editor.getTextInRange([[2, 0], [2, 6]])).toEqual '</bar>'
+
+
+    it 'does not get confused in case of self closing tags after the cursor', ->
+      waitsForPromise ->
+        atom.workspace.open('sample.xml')
+
+      runs ->
+        editor = atom.workspace.getActiveTextEditor()
+        editorElement = atom.views.getView(editor)
+
+        editor.setText """
+          <bar>
+
+            <bar>
+              <bar value="foo"/>
+            </bar>
+          </bar>
+        """
+
+        editor.setCursorBufferPosition([1, 0])
+        atom.commands.dispatch(editorElement, 'bracket-matcher:close-tag')
+
+        expect(editor.getCursorBufferPosition().row).toEqual 1
+        expect(editor.getCursorBufferPosition().column).toEqual 0
+        expect(editor.getTextInRange([[1, 0], [1, Infinity]])).toEqual ''
+
+    it 'does not get confused in case of nested self closing tags with `>` in their attributes', ->
+      waitsForPromise ->
+        atom.workspace.open('sample.xml')
+
+      runs ->
+        editor = atom.workspace.getActiveTextEditor()
+        editorElement = atom.views.getView(editor)
+
+        editor.setText """
+          <bar name="test">
+            <foo bar="test>1" baz="<>" value="15"/>
+
+        """
+
+        editor.setCursorBufferPosition([2, 0])
+        atom.commands.dispatch(editorElement, 'bracket-matcher:close-tag')
+
+        expect(editor.getCursorBufferPosition().row).toEqual 2
+        expect(editor.getCursorBufferPosition().column).toEqual 6
+        expect(editor.getTextInRange([[2, 0], [2, 6]])).toEqual '</bar>'
+
+        editor.setText """
+          <foo value="/>">
+
+        """
+
+        editor.setCursorBufferPosition([1, 0])
+        atom.commands.dispatch(editorElement, 'bracket-matcher:close-tag')
+
+        expect(editor.getCursorBufferPosition().row).toEqual 1
+        expect(editor.getCursorBufferPosition().column).toEqual 6
+        expect(editor.getTextInRange([[1, 0], [1, 6]])).toEqual '</foo>'
+
+    it 'does not get confused in case of self closing tags with `>` in their attributes after the cursor', ->
+      waitsForPromise ->
+        atom.workspace.open('sample.xml')
+
+      runs ->
+        editor = atom.workspace.getActiveTextEditor()
+        editorElement = atom.views.getView(editor)
+
+        editor.setText """
+          <bar>
+
+            <bar>
+              <bar value="b>z"/>
+            </bar>
+          </bar>
+        """
+
+        editor.setCursorBufferPosition([1, 0])
+        atom.commands.dispatch(editorElement, 'bracket-matcher:close-tag')
+
+        expect(editor.getCursorBufferPosition().row).toEqual 1
+        expect(editor.getCursorBufferPosition().column).toEqual 0
+        expect(editor.getTextInRange([[1, 0], [1, Infinity]])).toEqual ''

--- a/spec/close-tag-spec.coffee
+++ b/spec/close-tag-spec.coffee
@@ -26,12 +26,6 @@ describe 'closeTag', ->
       tags = tagFinder.tagsNotClosedInFragment(fragment)
       expect(tags).toEqual(['html', 'body', 'h1'])
 
-    # Is this desirable? It results in malformed XML for closing tag insertions.
-    it 'detects an incomplete tag', ->
-      fragment = '<html<body<h1'
-      tags = tagFinder.tagsNotClosedInFragment(fragment)
-      expect(tags).toEqual(['html', 'body', 'h1'])
-
     it 'is not confused by tag attributes', ->
       fragment = '<html><head></head><body class="c"><h1 class="p"><p></p>'
       tags = tagFinder.tagsNotClosedInFragment(fragment)


### PR DESCRIPTION
### Requirements

* [x] Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* [x] All new code requires tests to ensure against regressions

### Description of the Change
Adjust the tag regex used to find not closed tags to ignore self-closing tags.

### Alternate Designs
None

### Benefits
Will fix a bug (described in #203)

### Possible Drawbacks
None

### Applicable Issues
#203