### PR TITLE
Handle escaped characters when autocompleting quotes

### DIFF
--- a/lib/bracket-matcher.coffee
+++ b/lib/bracket-matcher.coffee
@@ -44,7 +44,7 @@ class BracketMatcher
       pair = @matchManager.pairedCharacters[text]
 
     skipOverExistingClosingBracket = false
-    if @isClosingBracket(text) and nextCharacter is text and not hasEscapeSequenceBeforeCursor
+    if @isClosingBracket(text) and nextCharacter is text and (previousCharacter isnt '\\' or '\\\\' is previousCharacters)
       if bracketMarker = _.find(@bracketMarkers, (marker) -> marker.isValid() and marker.getBufferRange().end.isEqual(cursorBufferPosition))
         skipOverExistingClosingBracket = true
 

--- a/lib/bracket-matcher.coffee
+++ b/lib/bracket-matcher.coffee
@@ -25,26 +25,31 @@ class BracketMatcher
     return true if @editor.hasMultipleCursors()
 
     cursorBufferPosition = @editor.getCursorBufferPosition()
-    previousCharacters = @editor.getTextInBufferRange([cursorBufferPosition.traverse([0, -2]), cursorBufferPosition])
+    previousCharacters = @editor.getTextInBufferRange([[cursorBufferPosition.row, 0], cursorBufferPosition])
     nextCharacter = @editor.getTextInBufferRange([cursorBufferPosition, cursorBufferPosition.traverse([0, 1])])
 
     previousCharacter = previousCharacters.slice(-1)
 
     hasWordAfterCursor = /\w/.test(nextCharacter)
     hasWordBeforeCursor = /\w/.test(previousCharacter)
-    hasQuoteBeforeCursor = previousCharacter is text[0]
-    hasEscapeSequenceBeforeCursor = previousCharacters.match(/\\/g)?.length >= 1 # To guard against the "\\" sequence
+    hasQuoteBeforeCursor = @isQuote(previousCharacter) and previousCharacter is text[0]
+    # Lone escape character - odd number of backslashes before cursor
+    hasEscapeCharacterBeforeCursor = previousCharacters.match(/(\\+)$/)?[1].length % 2 is 1
+    # Completed escape sequence - even number of backslashes or odd number of backslashes followed by a character before cursor
+    hasEscapeSequenceBeforeCursor = previousCharacters.match(/(\\+)[^\\]$/)?[1].length % 2 is 1 or previousCharacters.match(/(\\+)$/)?[1].length % 2 is 0
 
     if text is '#' and @isCursorOnInterpolatedString()
-      autoCompleteOpeningBracket = @getScopedSetting('bracket-matcher.autocompleteBrackets') and not hasEscapeSequenceBeforeCursor
+      autoCompleteOpeningBracket = @getScopedSetting('bracket-matcher.autocompleteBrackets') and not hasEscapeCharacterBeforeCursor
       text += '{'
       pair = '}'
     else
-      autoCompleteOpeningBracket = @getScopedSetting('bracket-matcher.autocompleteBrackets') and @isOpeningBracket(text) and not hasWordAfterCursor and not (@isQuote(text) and (hasWordBeforeCursor or hasQuoteBeforeCursor)) and not hasEscapeSequenceBeforeCursor
+      autoCompleteOpeningBracket = @getScopedSetting('bracket-matcher.autocompleteBrackets') and
+        @isOpeningBracket(text) and not hasWordAfterCursor and not
+        (@isQuote(text) and (hasWordBeforeCursor or hasQuoteBeforeCursor or hasEscapeSequenceBeforeCursor)) and not hasEscapeCharacterBeforeCursor
       pair = @matchManager.pairedCharacters[text]
 
     skipOverExistingClosingBracket = false
-    if @isClosingBracket(text) and nextCharacter is text and (previousCharacter isnt '\\' or '\\\\' is previousCharacters)
+    if @isClosingBracket(text) and nextCharacter is text and not hasEscapeCharacterBeforeCursor
       if bracketMarker = _.find(@bracketMarkers, (marker) -> marker.isValid() and marker.getBufferRange().end.isEqual(cursorBufferPosition))
         skipOverExistingClosingBracket = true
 
@@ -65,13 +70,15 @@ class BracketMatcher
     return unless @editor.getLastSelection().isEmpty()
 
     cursorBufferPosition = @editor.getCursorBufferPosition()
-    previousCharacters = @editor.getTextInBufferRange([cursorBufferPosition.traverse([0, -2]), cursorBufferPosition])
+    previousCharacters = @editor.getTextInBufferRange([[cursorBufferPosition.row, 0], cursorBufferPosition])
     nextCharacter = @editor.getTextInBufferRange([cursorBufferPosition, cursorBufferPosition.traverse([0, 1])])
 
     previousCharacter = previousCharacters.slice(-1)
 
-    hasEscapeSequenceBeforeCursor = previousCharacters.match(/\\/g)?.length >= 1 # To guard against the "\\" sequence
-    if @matchManager.pairsWithExtraNewline[previousCharacter] is nextCharacter and not hasEscapeSequenceBeforeCursor
+    # Lone escape character - odd number of backslashes before cursor
+    hasEscapeCharacterBeforeCursor = previousCharacters.match(/(\\+)$/)?[1].length % 2 is 1
+
+    if @matchManager.pairsWithExtraNewline[previousCharacter] is nextCharacter and not hasEscapeCharacterBeforeCursor
       @editor.transact =>
         @editor.insertText "\n\n"
         @editor.moveUp()
@@ -85,13 +92,15 @@ class BracketMatcher
     return unless @editor.getLastSelection().isEmpty()
 
     cursorBufferPosition = @editor.getCursorBufferPosition()
-    previousCharacters = @editor.getTextInBufferRange([cursorBufferPosition.traverse([0, -2]), cursorBufferPosition])
+    previousCharacters = @editor.getTextInBufferRange([[cursorBufferPosition.row, 0], cursorBufferPosition])
     nextCharacter = @editor.getTextInBufferRange([cursorBufferPosition, cursorBufferPosition.traverse([0, 1])])
 
     previousCharacter = previousCharacters.slice(-1)
 
-    hasEscapeSequenceBeforeCursor = previousCharacters.match(/\\/g)?.length >= 1 # To guard against the "\\" sequence
-    if (@matchManager.pairedCharacters[previousCharacter] is nextCharacter) and not hasEscapeSequenceBeforeCursor and @getScopedSetting('bracket-matcher.autocompleteBrackets')
+    # Lone escape character - odd number of backslashes before cursor
+    hasEscapeCharacterBeforeCursor = previousCharacters.match(/(\\+)$/)?[1].length % 2 is 1
+
+    if (@matchManager.pairedCharacters[previousCharacter] is nextCharacter) and not hasEscapeCharacterBeforeCursor and @getScopedSetting('bracket-matcher.autocompleteBrackets')
       @editor.transact =>
         @editor.moveLeft()
         @editor.delete()

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -687,23 +687,42 @@ describe "bracket matching", ->
         expect(buffer.lineForRow(0)).toBe "''"
         expect(editor.getCursorBufferPosition()).toEqual([0, 1])
 
-    describe "when the previous character is a backslash", ->
+    describe "when the cursor follows an escape character", ->
       it "doesn't insert a quote to match the escaped quote and overwrites the end quote", ->
         editor.buffer.setText('')
-        editor.insertText '\"'
+        editor.insertText '"'
         editor.insertText '\\'
-        editor.insertText '\"'
-        editor.insertText '\"'
-        expect(buffer.lineForRow(0)).toBe '\"\\\"\"'
+        editor.insertText '"'
+        editor.insertText '"'
+        expect(buffer.lineForRow(0)).toBe '"\\""'
 
-      describe "when the character before that is also a backslash", ->
-        it "inserts a matching quote and overwrites it", ->
-          editor.buffer.setText('')
-          editor.insertText '\"'
-          editor.insertText '\\'
-          editor.insertText '\\'
-          editor.insertText '\"'
-          expect(buffer.lineForRow(0)).toBe '\"\\\\\"'
+    describe "when the cursor follows an escape sequence", ->
+      it "inserts a matching quote and overwrites it", ->
+        editor.buffer.setText('')
+        editor.insertText '"'
+        editor.insertText '\\'
+        editor.insertText '\\'
+        editor.insertText '"'
+        expect(buffer.lineForRow(0)).toBe '"\\\\"'
+
+    describe "when the cursor follows a combination of escape characters", ->
+      it "correctly decides whether to match the quote or not", ->
+        editor.buffer.setText('')
+        editor.insertText '"'
+        editor.insertText '\\'
+        editor.insertText '\\'
+        editor.insertText '\\'
+        editor.insertText '"'
+        expect(buffer.lineForRow(0)).toBe '"\\\\\\""'
+
+        editor.buffer.setText('')
+        editor.insertText '"'
+        editor.insertText '\\'
+        editor.insertText '\\'
+        editor.insertText '\\'
+        editor.insertText '\\'
+        editor.insertText '"'
+        expect(buffer.lineForRow(0)).toBe '"\\\\\\\\"'
 
     describe "when the cursor is on a closing bracket and a closing bracket is inserted", ->
       describe "when the closing bracket was there previously", ->
@@ -846,7 +865,7 @@ describe "bracket matching", ->
           editor.insertText "'"
           expect(editor.getText()).toBe "abc'"
 
-      describe "when a backslash character is before the cursor", ->
+      describe "when an escape character is before the cursor", ->
         it "does not automatically insert the closing quote", ->
           editor.buffer.setText("\\")
           editor.moveToEndOfLine()
@@ -858,8 +877,6 @@ describe "bracket matching", ->
           editor.insertText "'"
           expect(editor.getText()).toBe "\\'"
 
-      describe "when an escape sequence is before the cursor", ->
-        it "does not automatically insert the closing quote", ->
           editor.buffer.setText('"\\"')
           editor.moveToEndOfLine()
           editor.insertText '"'
@@ -879,6 +896,50 @@ describe "bracket matching", ->
           editor.moveToEndOfLine()
           editor.insertText "'"
           expect(editor.getText()).toBe "'\\''"
+
+      describe "when an escape sequence is before the cursor", ->
+        it "does not create a new quote pair", ->
+          editor.buffer.setText('"\\\\"')
+          editor.moveToEndOfLine()
+          editor.insertText '"'
+          expect(editor.getText()).toBe '"\\\\""'
+
+          editor.buffer.setText("'\\\\'")
+          editor.moveToEndOfLine()
+          editor.insertText "'"
+          expect(editor.getText()).toBe "'\\\\''"
+
+      describe "when a combination of escape characters is before the cursor", ->
+        it "correctly determines whether it is an escape character or sequence", ->
+          editor.buffer.setText("\\\\\\")
+          editor.moveToEndOfLine()
+          editor.insertText '"'
+          expect(editor.getText()).toBe '\\\\\\"'
+
+          editor.buffer.setText("\\\\\\")
+          editor.moveToEndOfLine()
+          editor.insertText "'"
+          expect(editor.getText()).toBe "\\\\\\'"
+
+          editor.buffer.setText('"\\\\\\"')
+          editor.moveToEndOfLine()
+          editor.insertText '"'
+          expect(editor.getText()).toBe '"\\\\\\""'
+
+          editor.buffer.setText("\"\\\\\\'")
+          editor.moveToEndOfLine()
+          editor.insertText '"'
+          expect(editor.getText()).toBe "\"\\\\\\'\""
+
+          editor.buffer.setText("'\\\\\\\"")
+          editor.moveToEndOfLine()
+          editor.insertText "'"
+          expect(editor.getText()).toBe "'\\\\\\\"'"
+
+          editor.buffer.setText("'\\\\\\'")
+          editor.moveToEndOfLine()
+          editor.insertText "'"
+          expect(editor.getText()).toBe "'\\\\\\''"
 
       describe "when a quote is before the cursor", ->
         it "does not automatically insert the closing quote", ->

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -687,6 +687,24 @@ describe "bracket matching", ->
         expect(buffer.lineForRow(0)).toBe "''"
         expect(editor.getCursorBufferPosition()).toEqual([0, 1])
 
+    describe "when the previous character is a backslash", ->
+      it "doesn't insert a quote to match the escaped quote and overwrites the end quote", ->
+        editor.buffer.setText('')
+        editor.insertText '\"'
+        editor.insertText '\\'
+        editor.insertText '\"'
+        editor.insertText '\"'
+        expect(buffer.lineForRow(0)).toBe '\"\\\"\"'
+
+      describe "when the character before that is also a backslash", ->
+        it "inserts a matching quote and overwrites it", ->
+          editor.buffer.setText('')
+          editor.insertText '\"'
+          editor.insertText '\\'
+          editor.insertText '\\'
+          editor.insertText '\"'
+          expect(buffer.lineForRow(0)).toBe '\"\\\\\"'
+
     describe "when the cursor is on a closing bracket and a closing bracket is inserted", ->
       describe "when the closing bracket was there previously", ->
         it "inserts a closing bracket", ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR builds on #201.  Changes include:
* Rewriting the backslash-checking logic.  This was flat-out wrong to begin with, and could only check the two previous characters.
  * Now scans the entire line for a _continuous_ string of backslashes that terminate at the end of the line.
  * If the number of backslashes is odd, then there is an escape character and the quote will not be skipped.
* Adding a regex to check for escape _sequences_.
  * Similar to escape characters, except that the number of backslashes is even or there are an odd number of backslashes, followed by any character, followed by the end of the line.
  * If there is an escape sequence, quotes will not be paired.

Consequences of these changes:
* `"|"`, where `|` is the position of the cursor
  * Typing a backslash followed by a quote results in the same behavior as before: it inserts a new quote, rather than completing the quote pair
  * Typing two backslashes followed by a quote: quote pair is completed
  * Typing three backslashes followed by a quote: new quote is inserted, rather than completing the quote pair
* `"|`, where `|` is the position of the cursor
  * Typing any number of backslashes followed by a quote results in the same behavior as before: it inserts a single new quote

### Alternate Designs

None.

### Benefits

Finally being able to type double-backslashes without having to backspace, delete, and otherwise be annoyed

### Possible Drawbacks

Should be none.  I was unable to spot any regressions, and there's comprehensive test coverage.

### Applicable Issues

Fixes #80
Supersedes and closes #201