### PR TITLE
Fix memory leak in MatchManager

### DIFF
--- a/lib/match-manager.coffee
+++ b/lib/match-manager.coffee
@@ -38,6 +38,8 @@ class MatchManager
       @updateConfig()
     @subscriptions.add atom.config.observe 'bracket-matcher.pairsWithExtraNewline', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
       @updateConfig()
+      
+    @subscriptions.add @editor.onDidDestroy @destroy
 
   destroy: =>
     @subscriptions.dispose()


### PR DESCRIPTION
### Description of the Change

MatchManager attaches itself to various subscriptions of Atom configuration. However, these subscriptions are not released when the TextEditor is destroyed. This means that even after the TextEditor is destroyed, the subscriptions remain, which hold a reference to MatchManager, which in turn holds a reference to the TextEditor. This TextEditor holds many references to loaded file buffers, display buffers, etc. etc. and therefore causes a gradual increase in memory and slow down of Atom over time, demanding frequent restarts.

### Alternate Designs

None

### Benefits

Reduced memory leaks

### Possible Drawbacks

The MatchManager will likely release its subscriptions before the BracketMatcherView and BracketMatcher. Looking at the code I cannot see an issue arising from this.

### Applicable Issues

Fixes #283