### PR TITLE
Highlight matching line

### DIFF
--- a/lib/bracket-matcher-view.coffee
+++ b/lib/bracket-matcher-view.coffee
@@ -190,7 +190,7 @@ class BracketMatcherView
     marker = @editor.markBufferRange(bufferRange)
     @editor.decorateMarker(marker, type: 'highlight', class: 'bracket-matcher', deprecatedRegionClass: 'bracket-matcher')
     if atom.config.get('bracket-matcher.highlightMatchingLineNumber', scope: @editor.getRootScopeDescriptor()) and @gutter
-        @gutter.decorateMarker(marker, type: 'highlight', class: 'bracket-matcher', deprecatedRegionClass: 'bracket-matcher')
+      @gutter.decorateMarker(marker, type: 'highlight', class: 'bracket-matcher', deprecatedRegionClass: 'bracket-matcher')
     marker
 
   findCurrentPair: (matches) ->

--- a/lib/bracket-matcher-view.coffee
+++ b/lib/bracket-matcher-view.coffee
@@ -14,6 +14,7 @@ MAX_ROWS_TO_SCAN_BACKWARD_TRAVERSAL = Object.freeze(Point(-MAX_ROWS_TO_SCAN, 0))
 module.exports =
 class BracketMatcherView
   constructor: (@editor, editorElement, @matchManager) ->
+    @gutter = @editor.gutterWithName('line-number')
     @subscriptions = new CompositeDisposable
     @tagFinder = new TagFinder(@editor)
     @pairHighlighted = false
@@ -188,6 +189,8 @@ class BracketMatcherView
   createMarker: (bufferRange) ->
     marker = @editor.markBufferRange(bufferRange)
     @editor.decorateMarker(marker, type: 'highlight', class: 'bracket-matcher', deprecatedRegionClass: 'bracket-matcher')
+    if atom.config.get('bracket-matcher.highlightMatchingLineNumber', scope: @editor.getRootScopeDescriptor()) and @gutter
+        @gutter.decorateMarker(marker, type: 'highlight', class: 'bracket-matcher', deprecatedRegionClass: 'bracket-matcher')
     marker
 
   findCurrentPair: (matches) ->

--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
     },
     "highlightMatchingLineNumber": {
       "type": "boolean",
-      "default": true,
-      "description": "If the line number gutter is visible, highlight the line number of the matching bracket"
+      "default": false,
+      "description": "Highlight the line number of the matching bracket."
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,9 +58,9 @@
       "description": "Wrap selected text in brackets or quotes when the editor contains selections and the opening bracket or quote is typed."
     },
     "highlightMatchingLineNumber": {
-        "type": "boolean",
-        "default": true,
-        "description": "If the line number gutter is visible, highlight the line number of the matching bracket"
+      "type": "boolean",
+      "default": true,
+      "description": "If the line number gutter is visible, highlight the line number of the matching bracket"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,11 @@
       "type": "boolean",
       "default": true,
       "description": "Wrap selected text in brackets or quotes when the editor contains selections and the opening bracket or quote is typed."
+    },
+    "highlightMatchingLineNumber": {
+        "type": "boolean",
+        "default": true,
+        "description": "If the line number gutter is visible, highlight the line number of the matching bracket"
     }
   }
 }

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -23,6 +23,9 @@ describe "bracket matching", ->
       gutter = editor.gutterWithName('line-number')
 
   describe "matching bracket highlighting", ->
+    beforeEach ->
+      atom.config.set 'bracket-matcher.highlightMatchingLineNumber', true
+
     expectNoHighlights = ->
       decorations = editor.getHighlightDecorations().filter (decoration) -> decoration.properties.class is 'bracket-matcher'
       expect(decorations.length).toBe 0

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -1,5 +1,5 @@
 describe "bracket matching", ->
-  [editorElement, editor, buffer] = []
+  [editorElement, editor, buffer, gutter] = []
 
   beforeEach ->
     atom.config.set 'bracket-matcher.autocompleteBrackets', true
@@ -20,6 +20,7 @@ describe "bracket matching", ->
       editor = atom.workspace.getActiveTextEditor()
       editorElement = atom.views.getView(editor)
       buffer = editor.getBuffer()
+      gutter = editor.gutterWithName('line-number')
 
   describe "matching bracket highlighting", ->
     expectNoHighlights = ->
@@ -28,10 +29,16 @@ describe "bracket matching", ->
 
     expectHighlights = (startBufferPosition, endBufferPosition) ->
       decorations = editor.getHighlightDecorations().filter (decoration) -> decoration.properties.class is 'bracket-matcher'
+      gutterDecorations = editor.getLineNumberDecorations().filter (gutterDecoration) -> gutterDecoration.properties.class is 'bracket-matcher'
+
       expect(decorations.length).toBe 2
+      expect(gutterDecorations.length).toBe 2
 
       expect(decorations[0].marker.getStartBufferPosition()).toEqual startBufferPosition
       expect(decorations[1].marker.getStartBufferPosition()).toEqual endBufferPosition
+
+      expect(gutterDecorations[0].marker.getStartBufferPosition()).toEqual startBufferPosition
+      expect(gutterDecorations[1].marker.getStartBufferPosition()).toEqual endBufferPosition
 
     describe "when the cursor is before a starting pair", ->
       it "highlights the starting pair and ending pair", ->

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -195,6 +195,14 @@ describe "bracket matching", ->
         editor.getLastCursor().destroy()
         expectHighlights([0, 28], [12, 0])
 
+    describe "when highlightMatchingLineNumber config is disabled", ->
+      it "does not highlight the gutter", ->
+        atom.config.set('bracket-matcher.highlightMatchingLineNumber', false)
+        editor.moveToEndOfLine()
+        editor.moveLeft()
+        gutterDecorations = editor.getLineNumberDecorations().filter (gutterDecoration) -> gutterDecoration.properties.class is 'bracket-matcher'
+        expect(gutterDecorations.length).toBe 0
+
     describe "when the cursor moves off (clears) a selection next to a starting or ending pair", ->
       it "highlights the starting pair and ending pair", ->
         editor.moveToEndOfLine()

--- a/styles/bracket-matcher.atom-text-editor.less
+++ b/styles/bracket-matcher.atom-text-editor.less
@@ -4,5 +4,5 @@
 }
 
 .line-number.bracket-matcher {
-  background-color: #888888
+  background-color: @text-color-subtle
 }

--- a/styles/bracket-matcher.atom-text-editor.less
+++ b/styles/bracket-matcher.atom-text-editor.less
@@ -2,3 +2,7 @@
   border-bottom: 1px dotted lime;
   position: absolute;
 }
+
+.line-number.bracket-matcher {
+    background-color: #888888
+}

--- a/styles/bracket-matcher.atom-text-editor.less
+++ b/styles/bracket-matcher.atom-text-editor.less
@@ -4,5 +4,5 @@
 }
 
 .line-number.bracket-matcher {
-    background-color: #888888
+  background-color: #888888
 }


### PR DESCRIPTION
### Requirements

* In regards to #180, this is a bit of a simpler modification. It's purpose is to highlight the line number with the matching bracket

### Description of the Change

bracket-matcher already creates markers and decorates them. This pull request adds a highlight decoration to the line-number gutter if it is there.

### Alternate Designs

I attempted to merge #180 into the current code base, but that is way out of date and there were modifications I did not understand. This is the first package I've worked with in Atom, and my first time w/ CoffeeScript, so I kept it simple.

### Benefits

If you happen to have long blocks of code, you can more easily find the matching bracket.

### Possible Drawbacks

* Only works if you are showing line numbers. (Atom 1.18 and earlier only. In Atom 1.19+, this modification works when line numbers are hidden.)

### Applicable Issues

#97 
