### PR TITLE
Add support for code embedded in strings

### DIFF
--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -133,6 +133,30 @@ describe "bracket matching", ->
         editor.setCursorBufferPosition([0, 2])
         expectNoHighlights()
 
+    describe "when there are brackets inside code embedded in a string", ->
+      it "highlights the correct start/end pairs", ->
+        editor.setText "(`${(1+1)}`)"
+        editor.setCursorBufferPosition([0, 0])
+        expectHighlights([0, 0], [0, 11])
+
+        editor.setCursorBufferPosition([0, 12])
+        expectHighlights([0, 11], [0, 0])
+
+        editor.setCursorBufferPosition([0, 4])
+        expectHighlights([0, 4], [0, 8])
+
+    describe "when there are brackets inside a string inside code embedded in a string", ->
+      it "highlights the correct start/end pairs", ->
+        editor.setText "(`${('(1+1)')}`)"
+        editor.setCursorBufferPosition([0, 0])
+        expectHighlights([0, 0], [0, 15])
+
+        editor.setCursorBufferPosition([0, 16])
+        expectHighlights([0, 15], [0, 0])
+
+        editor.setCursorBufferPosition([0, 6])
+        expectNoHighlights()
+
     describe "when there are brackets in regular expressions", ->
       it "highlights the correct start/end pairs", ->
         editor.setText "(/[)]/)"


### PR DESCRIPTION
This PR will implement #274. This means it will allow bracket matching for embedded code like this:
```js
`${(15 + 5) * 5}`
   ^      ^
```
The `^` marks the highlighting.

### Description of the Change

The `BracketMatcherView` detects if the current bracket is inside a comment or a string and in this case ignores it completely. In order to allow embedded code I changed the why this happens. Previously a `ScopeSelector` was used. I replaced the selector with a manual check.

### Alternate Designs

I first tried implementing this by just changing the `commentOrStringSelector` selector. But was unable to do so. As far as I can tell this would require a negative lookahead and I couldn't find anything like this for scope selectors.

### Benefits

Add the enhancement described in #274. Perhaps it even fixes a regression introduced by #253, but that's a matter of interpretation.

### Possible Drawbacks

Code like this will match like so:
```js
1 foo = (`
2       ^
3 ${ )}
4    ^
5 `)
```

However I think that is not much of a problem since the single braked in line 4 would be a syntax error.

### Applicable Issues

#274

### Additional Information

In #274 @schlomo pointed out that this is also a problem for shell code ([comment](https://github.com/atom/bracket-matcher/issues/274#issuecomment-299443285)).
However because the [language-shellscript](https://github.com/atom/language-shellscript) package uses the scope `string.interpolated.dollar.shell` for code embedded via`$()` and this PR checks for the scope `embedded.source.*` this PR won't fix the issue for shell code. I think this is an issue with the language package but I could also add an alias for this scope.

