### PR TITLE
Match the exact tag name when looking for closing tags

### DIFF
--- a/lib/tag-finder.coffee
+++ b/lib/tag-finder.coffee
@@ -13,7 +13,7 @@ COMMENT_SELECTOR_REGEX = /(\b|\.)comment/
 # The resulting RegExp.
 generateTagStartOrEndRegex = (tagNameRegexStr) ->
   notSelfClosingTagEnd = "(?:[^>\\/\"']|\"[^\"]*\"|'[^']*')*>"
-  re = new RegExp("<(#{tagNameRegexStr})#{notSelfClosingTagEnd}|<\\/(#{tagNameRegexStr})")
+  re = new RegExp("<(#{tagNameRegexStr})#{notSelfClosingTagEnd}|<\\/(#{tagNameRegexStr})>")
 
 tagStartOrEndRegex = generateTagStartOrEndRegex("\\w[-\\w]*(?:\\:\\w[-\\w]*)?")
 

--- a/spec/close-tag-spec.coffee
+++ b/spec/close-tag-spec.coffee
@@ -78,3 +78,8 @@ describe 'closeTag', ->
       preFragment = "<html><head></head><body><h1></h1><my-element>"
       postFragment = "</body></html>"
       expect(tagFinder.closingTagForFragments(preFragment, postFragment)).toBe("my-element")
+
+    it 'correctly closes tags when there are other tags with the same prefix', ->
+      preFragment = "<thead><th>"
+      postFragment = "</thead>"
+      expect(tagFinder.closingTagForFragments(preFragment, postFragment)).toBe("th")


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Previously, the closing tag regex only checked that the _start_ of the closing tag was the same as the tag that was being closed.  In other words, if a search was being done for a closing `th` tag, a closing `thead` would match.  This PR simply makes the regex match the entirety of the tag by additionally looking for the closing `>` rather than just the opening `<tag-name-here`.

### Alternate Designs

None.

### Benefits

Closing tags when there are similar tags around it should work better now.

### Possible Drawbacks

The only drawback I can imagine from this change is if there's some style of HTML where the closing tag is not strictly `</tag-name-here>`.

### Applicable Issues

Closes #133