### PR TITLE
Skip over tag attributes when selecting inside tags

### DIFF
--- a/lib/bracket-matcher-view.coffee
+++ b/lib/bracket-matcher-view.coffee
@@ -264,28 +264,29 @@ class BracketMatcherView
       startRange = @startMarker.getBufferRange()
       endRange = @endMarker.getBufferRange()
 
+      if @tagHighlighted
+        {startRange, endRange} = @tagFinder.findEnclosingTags(true)
+
       if startRange.compare(endRange) > 0
         [startRange, endRange] = [endRange, startRange]
 
-      if @tagHighlighted
-        startPosition = startRange.end
-        endPosition = endRange.start.traverse(TWO_CHARS_BACKWARD_TRAVERSAL) # Don't select </
-      else
-        startPosition = startRange.start
-        endPosition = endRange.start
+      startPosition = startRange.end
+      endPosition = endRange.start
     else
       if startPosition = @findAnyStartPair(@editor.getCursorBufferPosition())
         startPair = @editor.getTextInRange(Range.fromPointWithDelta(startPosition, 0, 1))
         endPosition = @findMatchingEndPair(startPosition, startPair, @matchManager.pairedCharacters[startPair])
-      else if pair = @tagFinder.findEnclosingTags()
+        startPosition = startPosition.traverse([0, 1])
+      else if pair = @tagFinder.findEnclosingTags(true)
         {startRange, endRange} = pair
         if startRange.compare(endRange) > 0
           [startRange, endRange] = [endRange, startRange]
+
         startPosition = startRange.end
-        endPosition = endRange.start.traverse(TWO_CHARS_BACKWARD_TRAVERSAL) # Don't select </
+        endPosition = endRange.start
 
     if startPosition? and endPosition?
-      rangeToSelect = new Range(startPosition.traverse(ONE_CHAR_FORWARD_TRAVERSAL), endPosition)
+      rangeToSelect = new Range(startPosition, endPosition)
       @editor.setSelectedBufferRange(rangeToSelect)
 
   # Insert at the current cursor position a closing tag if there exists an

--- a/lib/tag-finder.coffee
+++ b/lib/tag-finder.coffee
@@ -57,7 +57,7 @@ class TagFinder
 
     scopeIds.some (scopeId) -> regex.test(grammar.scopeForId(scopeId))
 
-  findStartTag: (tagName, endPosition) ->
+  findStartTag: (tagName, endPosition, fullRange=false) ->
     scanRange = new Range([0, 0], endPosition)
     pattern = @patternForTagName(tagName)
     startRange = null
@@ -68,7 +68,11 @@ class TagFinder
       if match[1]
         unpairedCount--
         if unpairedCount < 0
-          startRange = range.translate([0, 1], [0, -(match[2].length + match[3].length)]) # Subtract < and tag name suffix from range
+          startRange = range
+          unless fullRange
+            # Subtract < and tag name suffix from range
+            startRange = range.translate([0, 1], [0, -(match[2].length + match[3].length)])
+
           until startRange.end.column > 0 # if the tag spans multiple lines, the end.column is negative, so iterate until it's not.
             startRange.end.row -= 1 # move the end up one row
             startRange.end.column = @editor.getBuffer().lineLengthForRow(startRange.end.row) + startRange.end.column + 2 # and set the column
@@ -78,7 +82,7 @@ class TagFinder
 
     startRange
 
-  findEndTag: (tagName, startPosition) ->
+  findEndTag: (tagName, startPosition, fullRange=false) ->
     scanRange = new Range(startPosition, @editor.buffer.getEndPosition())
     pattern = @patternForTagName(tagName)
     endRange = null
@@ -91,12 +95,13 @@ class TagFinder
       else
         unpairedCount--
         if unpairedCount < 0
-          endRange = range.translate([0, 2], [0, -1]) # Subtract </ and > from range
+          endRange = range
+          endRange = range.translate([0, 2], [0, -1]) unless fullRange # Subtract </ and > from range
           stop()
 
     endRange
 
-  findStartEndTags: ->
+  findStartEndTags: (fullRange=false) ->
     ranges = null
     endPosition = @editor.getLastCursor().getCurrentWordBufferRange({@wordRegex}).end
     @editor.backwardsScanInBufferRange @tagPattern, [[0, 0], endPosition], ({match, range, stop}) =>
@@ -110,9 +115,12 @@ class TagFinder
         startRange = Range.fromObject([range.start.translate([0, prefix.length]), [range.start.row, tagName.length+1]])
 
       if isClosingTag
-        endRange = @findStartTag(tagName, startRange.start)
+        endRange = @findStartTag(tagName, startRange.start, fullRange)
       else
-        endRange = @findEndTag(tagName, startRange.end)
+        endRange = @findEndTag(tagName, startRange.end, fullRange)
+
+      if fullRange
+        startRange = range
 
       if isSelfClosingTag
         endRange = startRange
@@ -120,13 +128,12 @@ class TagFinder
       ranges = {startRange, endRange} if startRange? and endRange?
     ranges
 
-  findEnclosingTags: ->
-    if ranges = @findStartEndTags()
+  findEnclosingTags: (fullRange=false) ->
+    if ranges = @findStartEndTags(fullRange)
       if @isTagRange(ranges.startRange) and @isTagRange(ranges.endRange)
-        if ranges.startRange.start.row > ranges.endRange.start.row # if the endRange occurs after the startRange in the buffer, switch them
-          tempRange = ranges.startRange
-          ranges.startRange = ranges.endRange
-          ranges.endRange = tempRange
+        if ranges.startRange.start.row > ranges.endRange.start.row
+          # If the endRange occurs after the startRange in the buffer, switch them
+          [ranges.startRange, ranges.endRange] = [ranges.endRange, ranges.startRange]
         return ranges
 
     null

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -569,15 +569,20 @@ describe "bracket matching", ->
 
       describe 'when the cursor is on an ending tag', ->
         it 'selects the text inside the starting/closing tag', ->
-          editor.setCursorBufferPosition([15, 8])
+          editor.setCursorBufferPosition([14, 9])
           atom.commands.dispatch(editorElement, "bracket-matcher:select-inside-brackets")
-          expect(editor.getSelectedBufferRange()).toEqual [[1, 8], [15, 2]]
+          expect(editor.getSelectedBufferRange()).toEqual [[10, 9], [14, 4]]
 
       describe 'when the cursor is inside a tag', ->
         it 'selects the text inside the starting/closing tag', ->
           editor.setCursorBufferPosition([12, 8])
           atom.commands.dispatch(editorElement, "bracket-matcher:select-inside-brackets")
           expect(editor.getSelectedBufferRange()).toEqual [[11, 11], [13, 6]]
+
+      it 'does not select attributes inside tags', ->
+        editor.setCursorBufferPosition([1, 10])
+        atom.commands.dispatch(editorElement, "bracket-matcher:select-inside-brackets")
+        expect(editor.getSelectedBufferRange()).toEqual [[1, 17], [15, 2]]
 
   describe "when bracket-matcher:remove-matching-brackets is triggered", ->
     describe "when the cursor is not in front of any pair", ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

When selecting inside tags, grab the full range of the tag rather than just the tag name range.  This change allows the attributes to be skipped, leading to the actual area between tags being highlighted.

### Alternate Designs

None.

### Benefits

Using the `bracket-matcher:select-inside-brackets` command will work correctly for tags with attributes.

### Possible Drawbacks

There may be a slight performance decrease compared to before when the cursor is currently on a tag.  This is because we have to re-search for the tags in order to get the full range (i.e. there is no way that I know of to grab the full range from the existing range).

### Applicable Issues

Fixes #117