### PR TITLE
Guard against null tokenizedLineForRow

### DIFF
--- a/lib/tag-finder.coffee
+++ b/lib/tag-finder.coffee
@@ -42,8 +42,9 @@ class TagFinder
     {tokenizedBuffer, buffer} = @editor
     {grammar} = tokenizedBuffer
     column = 0
-    lineLength = buffer.lineLengthForRow(position.row)
     line = tokenizedBuffer.tokenizedLineForRow(position.row)
+    return false unless line?
+    lineLength = buffer.lineLengthForRow(position.row)
     scopeIds = line.openScopes.slice()
     for tag in line.tags by 1
       if tag >= 0


### PR DESCRIPTION
`tokenizedBuffer.tokenizedLineForRow` is not guaranteed to return a valid line if a non-existent row is passed in. The easiest way to repro this is:

1. Open a file, `test.txt`, in Atom, and move the cursor to a random line.
2. Quit Atom (the cursor position is serialized).
3. Delete `test.txt`.
4. Re-open Atom. `test.txt` attempts to open to the old cursor position.
5. `bracket-matcher` attempts to read information about the old cursor position and throws.

The easiest workaround is to check for a null return and return early. Fixes #292.

Released under CC0.