### PR TITLE
Fix performance regression when there is no >

### DIFF
--- a/lib/bracket-matcher-view.coffee
+++ b/lib/bracket-matcher-view.coffee
@@ -260,7 +260,7 @@ class BracketMatcherView
       {startRange, endRange} = pair
       if startRange.compare(endRange) > 0
         [startRange, endRange] = [endRange, startRange]
-      @editor.setCursorBufferPosition(pair.startRange.start)
+      @editor.setCursorBufferPosition(startRange.start)
 
   selectInsidePair: ->
     if @pairHighlighted

--- a/lib/tag-finder.coffee
+++ b/lib/tag-finder.coffee
@@ -119,7 +119,7 @@ class TagFinder
 
   findStartEndTags: ->
     ranges = null
-    endPosition = @editor.getLastCursor().getCurrentWordBufferRange({wordRegex: @endOfTagRegex}).end
+    endPosition = @editor.getLastCursor().getCurrentWordBufferRange({@wordRegex}).end
 
     @editor.backwardsScanInBufferRange @tagPattern, [[0, 0], endPosition], ({match, range, stop}) =>
       stop()

--- a/lib/tag-finder.coffee
+++ b/lib/tag-finder.coffee
@@ -119,9 +119,7 @@ class TagFinder
 
   findStartEndTags: ->
     ranges = null
-    endPosition = null
-    cursorPosition = @editor.getCursorBufferPosition()
-    endPosition = @editor.getLastCursor().getCurrentWordBufferRange({@wordRegex}).end
+    endPosition = @editor.getLastCursor().getCurrentWordBufferRange({wordRegex: @endOfTagRegex}).end
 
     @editor.backwardsScanInBufferRange @tagPattern, [[0, 0], endPosition], ({match, range, stop}) =>
       stop()

--- a/lib/tag-finder.coffee
+++ b/lib/tag-finder.coffee
@@ -120,7 +120,6 @@ class TagFinder
   findStartEndTags: ->
     ranges = null
     endPosition = @editor.getLastCursor().getCurrentWordBufferRange({@wordRegex}).end
-
     @editor.backwardsScanInBufferRange @tagPattern, [[0, 0], endPosition], ({match, range, stop}) =>
       stop()
 

--- a/lib/tag-finder.coffee
+++ b/lib/tag-finder.coffee
@@ -27,8 +27,8 @@ class TagFinder
     # 4. Attributes (ids, classes, etc. - optional)
     # 5. Tag suffix
     # 6. Self-closing tag (optional)
-    @tagPattern = /(<(\/)?)(.+?)(\s+.*?)?((\/)?>)/
-    @endOfTagRegex = /[\W\w\s]*?>/ # Aka match everything until a > is reached
+    @tagPattern = /(<(\/)?)(.+?)(\s+.*?)?((\/)?>|$)/
+    @wordRegex = /.*?(>|$)/
 
   patternForTagName: (tagName) ->
     tagName = _.escapeRegExp(tagName)
@@ -121,13 +121,7 @@ class TagFinder
     ranges = null
     endPosition = null
     cursorPosition = @editor.getCursorBufferPosition()
-    # TODO: When JS has lookbehind support, add it to the endOfTagRegex and remove this conditional
-    # e.g. /(?<=>)|[\W\w\s]*?>/
-    if cursorPosition.column > 0 and
-    @editor.getTextInBufferRange([[cursorPosition.row, cursorPosition.column - 1], cursorPosition]) is '>'
-      endPosition = cursorPosition
-    else
-      endPosition = @editor.getLastCursor().getCurrentWordBufferRange({wordRegex: @endOfTagRegex}).end
+    endPosition = @editor.getLastCursor().getCurrentWordBufferRange({@wordRegex}).end
 
     @editor.backwardsScanInBufferRange @tagPattern, [[0, 0], endPosition], ({match, range, stop}) =>
       stop()

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -595,6 +595,16 @@ describe "bracket matching", ->
         atom.commands.dispatch(editorElement, "bracket-matcher:select-inside-brackets")
         expect(editor.getSelectedBufferRange()).toEqual [[4, 29], [7, 4]]
 
+    describe 'when there are no brackets or tags', ->
+      it 'does not catastrophically backtrack (regression)', ->
+        buffer.setText "#{'a'.repeat(500)}\n".repeat(500)
+        editor.setCursorBufferPosition([0, 500])
+
+        start = Date.now()
+        atom.commands.dispatch(editorElement, "bracket-matcher:select-inside-brackets")
+        expect(editor.getSelectedBufferRange()).toEqual [[0, 500], [0, 500]]
+        expect(Date.now() - start).toBeLessThan(5000)
+
     describe 'HTML/XML text', ->
       beforeEach ->
         waitsForPromise ->


### PR DESCRIPTION
WIP

This works, but I'm not sure if it introduces other regressions (unlikely, but I'm not the one to say :blush:).  It would also be nice to change this to use scopes instead of using word boundaries to find tag boundaries.

Fixes #314