### PR TITLE
Don't watch editors more than once if they're re-added to the workspace

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -4,8 +4,14 @@ BracketMatcher = require './bracket-matcher'
 
 module.exports =
   activate: ->
+    watchedEditors = new WeakSet()
+
     atom.workspace.observeTextEditors (editor) ->
+      return if watchedEditors.has(editor)
+
       editorElement = atom.views.getView(editor)
       matchManager = new MatchManager(editor, editorElement)
       new BracketMatcherView(editor, editorElement, matchManager)
       new BracketMatcher(editor, editorElement, matchManager)
+      watchedEditors.add(editor)
+      editor.onDidDestroy -> watchedEditors.delete(editor)


### PR DESCRIPTION
This will prevent this package from providing its functionality to editors more than once in case they get added to the workspace, then removed from it and finally added back.

/cc: @nathansobo @jasonrudolph