### PR TITLE
Add bracket select and replace

### DIFF
--- a/keymaps/bracket-matcher.cson
+++ b/keymaps/bracket-matcher.cson
@@ -6,13 +6,16 @@
   'ctrl-cmd-m': 'bracket-matcher:select-inside-brackets'
   'alt-cmd-.': 'bracket-matcher:close-tag'
   'ctrl-backspace': 'bracket-matcher:remove-matching-brackets'
+  'ctrl-alt-c': 'bracket-matcher:select-matching-brackets'
 
 '.platform-linux atom-text-editor':
   'ctrl-alt-,': 'bracket-matcher:select-inside-brackets'
   'ctrl-alt-.': 'bracket-matcher:close-tag'
   'ctrl-alt-backspace': 'bracket-matcher:remove-matching-brackets'
+  'ctrl-alt-c': 'bracket-matcher:select-matching-brackets'
 
 '.platform-win32 atom-text-editor':
   'ctrl-alt-,': 'bracket-matcher:select-inside-brackets'
   'ctrl-alt-.': 'bracket-matcher:close-tag'
   'ctrl-alt-backspace': 'bracket-matcher:remove-matching-brackets'
+  'ctrl-alt-c': 'bracket-matcher:select-matching-brackets'

--- a/lib/bracket-matcher-view.coffee
+++ b/lib/bracket-matcher-view.coffee
@@ -101,7 +101,7 @@ class BracketMatcherView
   selectMatchingBrackets: ->
     return unless @bracket1Range or @bracket2Range
     @editor.setSelectedBufferRanges([@bracket1Range, @bracket2Range])
-    @matchManager.changeBracketsMode = true;
+    @matchManager.changeBracketsMode = true
 
 
   removeMatchingBrackets: ->

--- a/lib/bracket-matcher-view.coffee
+++ b/lib/bracket-matcher-view.coffee
@@ -101,6 +101,7 @@ class BracketMatcherView
   selectMatchingBrackets: ->
     return unless @bracket1Range or @bracket2Range
     @editor.setSelectedBufferRanges([@bracket1Range, @bracket2Range])
+    @matchManager.changeBracketsMode = true;
 
 
   removeMatchingBrackets: ->

--- a/lib/bracket-matcher.coffee
+++ b/lib/bracket-matcher.coffee
@@ -21,6 +21,21 @@ class BracketMatcher
     return true unless text
     return true if options?.select or options?.undo is 'skip'
 
+    if @matchManager.changeBracketsMode
+      @matchManager.changeBracketsMode = false
+      if @isClosingBracket( text )
+        text = @matchManager.pairedCharactersInverse[text]
+      if @isOpeningBracket( text )
+        @editor.mutateSelectedText (selection) =>
+          selectionText = selection.getText()
+          if @isOpeningBracket( selectionText )
+            selection.insertText(text)
+          if @isClosingBracket(selectionText)
+            selection.insertText( @matchManager.pairedCharacters[text] )
+        return false
+
+
+
     return false if @wrapSelectionInBrackets(text)
     return true if @editor.hasMultipleCursors()
 

--- a/lib/bracket-matcher.coffee
+++ b/lib/bracket-matcher.coffee
@@ -34,8 +34,6 @@ class BracketMatcher
             selection.insertText( @matchManager.pairedCharacters[text] )
         return false
 
-
-
     return false if @wrapSelectionInBrackets(text)
     return true if @editor.hasMultipleCursors()
 

--- a/lib/match-manager.coffee
+++ b/lib/match-manager.coffee
@@ -38,8 +38,10 @@ class MatchManager
       @updateConfig()
     @subscriptions.add atom.config.observe 'bracket-matcher.pairsWithExtraNewline', {scope: @editor.getRootScopeDescriptor()}, (newConfig) =>
       @updateConfig()
-      
+
     @subscriptions.add @editor.onDidDestroy @destroy
+
+    @changeBracketsMode = false;
 
   destroy: =>
     @subscriptions.dispose()

--- a/lib/match-manager.coffee
+++ b/lib/match-manager.coffee
@@ -41,7 +41,7 @@ class MatchManager
 
     @subscriptions.add @editor.onDidDestroy @destroy
 
-    @changeBracketsMode = false;
+    @changeBracketsMode = false
 
   destroy: =>
     @subscriptions.dispose()

--- a/menus/bracket-matcher.cson
+++ b/menus/bracket-matcher.cson
@@ -9,6 +9,7 @@
         { 'label': 'Remove Brackets From Selection', 'command': 'bracket-matcher:remove-brackets-from-selection' }
         { 'label': 'Close Current Tag', 'command': 'bracket-matcher:close-tag' }
         { 'label': 'Remove Matching Brackets', 'command': 'bracket-matcher:remove-matching-brackets' }
+        { 'label': 'Select Matching Brackets', 'command': 'bracket-matcher:select-matching-brackets' }
       ]
     ]
   },

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -1454,3 +1454,28 @@ describe "bracket matching", ->
         expect(editor.getCursorBufferPosition().row).toEqual 1
         expect(editor.getCursorBufferPosition().column).toEqual 0
         expect(editor.getTextInRange([[1, 0], [1, Infinity]])).toEqual ''
+
+  describe "when bracket-matcher:select-matching-brackets is triggered", ->
+    describe "when the cursor on the left side of an opening bracket", ->
+      it "selects the brackets", ->
+        editor.setCursorBufferPosition([0, 28])
+        atom.commands.dispatch(editorElement, "bracket-matcher:select-matching-brackets")
+        expect(editor.getSelectedBufferRanges()).toEqual [[[0, 28], [0,29]], [[12, 0], [12, 1]]]
+
+    describe "when the cursor on the right side of an opening bracket", ->
+      it "selects the brackets", ->
+        editor.setCursorBufferPosition([1, 30])
+        atom.commands.dispatch(editorElement, "bracket-matcher:select-matching-brackets")
+        expect(editor.getSelectedBufferRanges()).toEqual [[[1, 29], [1, 30]], [[9, 2], [9, 3]]]
+
+    describe "when the cursor on the left side of an closing bracket", ->
+      it "selects the brackets", ->
+        editor.setCursorBufferPosition([12, 0])
+        atom.commands.dispatch(editorElement, "bracket-matcher:select-matching-brackets")
+        expect(editor.getSelectedBufferRanges()).toEqual [ [[12, 0], [12, 1]], [[0, 28], [0,29]] ]
+
+    describe "when the cursor isn't near to a bracket", ->
+      it "Don't selects the brackets", ->
+        editor.setCursorBufferPosition([1, 5])
+        atom.commands.dispatch(editorElement, "bracket-matcher:select-matching-brackets")
+        expect(editor.getSelectedBufferRanges()).toEqual [[[1, 5], [1, 5]]]

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -1462,10 +1462,10 @@ describe "bracket matching", ->
         atom.commands.dispatch(editorElement, "bracket-matcher:select-matching-brackets")
 
       it "selects the brackets", ->
-        expect(editor.getSelectedBufferRanges()).toEqual [[[0, 28], [0,29]], [[12, 0], [12, 1]]]
+        expect(editor.getSelectedBufferRanges()).toEqual [[[0, 28], [0, 29]], [[12, 0], [12, 1]]]
       it "select and replace", ->
         editor.insertText("[")
-        expect(editor.getTextInRange([[0, 28], [0,29]])).toEqual '['
+        expect(editor.getTextInRange([[0, 28], [0, 29]])).toEqual '['
         expect(editor.getTextInRange([[12, 0], [12, 1]])).toEqual ']'
 
     describe "when the cursor on the right side of an opening bracket", ->
@@ -1484,11 +1484,11 @@ describe "bracket matching", ->
         editor.setCursorBufferPosition([12, 0])
         atom.commands.dispatch(editorElement, "bracket-matcher:select-matching-brackets")
       it "selects the brackets", ->
-        expect(editor.getSelectedBufferRanges()).toEqual [ [[12, 0], [12, 1]], [[0, 28], [0,29]] ]
+        expect(editor.getSelectedBufferRanges()).toEqual [ [[12, 0], [12, 1]], [[0, 28], [0, 29]] ]
       it "select and replace", ->
         editor.insertText("[")
         expect(editor.getTextInRange([[12, 0], [12, 1]])).toEqual ']'
-        expect(editor.getTextInRange([[0, 28], [0,29]])).toEqual '['
+        expect(editor.getTextInRange([[0, 28], [0, 29]])).toEqual '['
 
     describe "when the cursor isn't near to a bracket", ->
       beforeEach ->

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -1457,25 +1457,45 @@ describe "bracket matching", ->
 
   describe "when bracket-matcher:select-matching-brackets is triggered", ->
     describe "when the cursor on the left side of an opening bracket", ->
-      it "selects the brackets", ->
+      beforeEach ->
         editor.setCursorBufferPosition([0, 28])
         atom.commands.dispatch(editorElement, "bracket-matcher:select-matching-brackets")
+
+      it "selects the brackets", ->
         expect(editor.getSelectedBufferRanges()).toEqual [[[0, 28], [0,29]], [[12, 0], [12, 1]]]
+      it "select and replace", ->
+        editor.insertText("[")
+        expect(editor.getTextInRange([[0, 28], [0,29]])).toEqual '['
+        expect(editor.getTextInRange([[12, 0], [12, 1]])).toEqual ']'
 
     describe "when the cursor on the right side of an opening bracket", ->
-      it "selects the brackets", ->
+      beforeEach ->
         editor.setCursorBufferPosition([1, 30])
         atom.commands.dispatch(editorElement, "bracket-matcher:select-matching-brackets")
+      it "selects the brackets", ->
         expect(editor.getSelectedBufferRanges()).toEqual [[[1, 29], [1, 30]], [[9, 2], [9, 3]]]
+      it "select and replace", ->
+        editor.insertText("[")
+        expect(editor.getTextInRange([[1, 29], [1, 30]])).toEqual '['
+        expect(editor.getTextInRange([[9, 2], [9, 3]])).toEqual ']'
 
     describe "when the cursor on the left side of an closing bracket", ->
-      it "selects the brackets", ->
+      beforeEach ->
         editor.setCursorBufferPosition([12, 0])
         atom.commands.dispatch(editorElement, "bracket-matcher:select-matching-brackets")
+      it "selects the brackets", ->
         expect(editor.getSelectedBufferRanges()).toEqual [ [[12, 0], [12, 1]], [[0, 28], [0,29]] ]
+      it "select and replace", ->
+        editor.insertText("[")
+        expect(editor.getTextInRange([[12, 0], [12, 1]])).toEqual ']'
+        expect(editor.getTextInRange([[0, 28], [0,29]])).toEqual '['
 
     describe "when the cursor isn't near to a bracket", ->
-      it "Don't selects the brackets", ->
+      beforeEach ->
         editor.setCursorBufferPosition([1, 5])
         atom.commands.dispatch(editorElement, "bracket-matcher:select-matching-brackets")
+      it "Don't selects the brackets", ->
         expect(editor.getSelectedBufferRanges()).toEqual [[[1, 5], [1, 5]]]
+      it "Don't select and replace the brackets", ->
+        editor.insertText("[")
+        expect(editor.getTextInRange([[1, 5], [1, 6]])).toEqual '['


### PR DESCRIPTION
### Description of the Change
A new command to brackets pair selection when cursor is near one of bracket. After selection the pair can be replaced by another.

### Alternate Designs
None

### Benefits
New command `bracket-matcher:select-matching-brackets`
New behavior after this command

### Possible Drawbacks
There may be new bugs?

### Applicable Issues
Fixes #280
