### PR TITLE
Added option to always skip over pair in front of cursor

### DIFF
--- a/lib/bracket-matcher.coffee
+++ b/lib/bracket-matcher.coffee
@@ -54,11 +54,11 @@ class BracketMatcher
 
     skipOverExistingClosingBracket = false
     if @isClosingBracket(text) and nextCharacter is text and not hasEscapeCharacterBeforeCursor
-      if bracketMarker = _.find(@bracketMarkers, (marker) -> marker.isValid() and marker.getBufferRange().end.isEqual(cursorBufferPosition))
+      if (bracketMarker = _.find(@bracketMarkers, (marker) -> marker.isValid() and marker.getBufferRange().end.isEqual(cursorBufferPosition))) or @getScopedSetting("bracket-matcher.alwaysSkipClosingPairs")
         skipOverExistingClosingBracket = true
 
     if skipOverExistingClosingBracket
-      bracketMarker.destroy()
+      bracketMarker?.destroy()
       _.remove(@bracketMarkers, bracketMarker)
       @editor.moveRight()
       false

--- a/lib/bracket-matcher.coffee
+++ b/lib/bracket-matcher.coffee
@@ -54,7 +54,8 @@ class BracketMatcher
 
     skipOverExistingClosingBracket = false
     if @isClosingBracket(text) and nextCharacter is text and not hasEscapeCharacterBeforeCursor
-      if (bracketMarker = _.find(@bracketMarkers, (marker) -> marker.isValid() and marker.getBufferRange().end.isEqual(cursorBufferPosition))) or @getScopedSetting("bracket-matcher.alwaysSkipClosingPairs")
+      bracketMarker = _.find(@bracketMarkers, (marker) -> marker.isValid() and marker.getBufferRange().end.isEqual(cursorBufferPosition))
+      if bracketMarker or @getScopedSetting("bracket-matcher.alwaysSkipClosingPairs")
         skipOverExistingClosingBracket = true
 
     if skipOverExistingClosingBracket

--- a/package.json
+++ b/package.json
@@ -61,6 +61,11 @@
       "type": "boolean",
       "default": false,
       "description": "Highlight the line number of the matching bracket."
+    },
+    "alwaysSkipClosingPairs": {
+      "type": "boolean",
+      "default": false,
+      "description": "Always skip closing pairs in front of the cursor."
     }
   }
 }

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -1454,3 +1454,26 @@ describe "bracket matching", ->
         expect(editor.getCursorBufferPosition().row).toEqual 1
         expect(editor.getCursorBufferPosition().column).toEqual 0
         expect(editor.getTextInRange([[1, 0], [1, Infinity]])).toEqual ''
+
+  describe "skipping closed brackets", ->
+    beforeEach ->
+      editor.buffer.setText("")
+
+    it "skips over brackets", ->
+      editor.insertText("(")
+      expect(editor.buffer.getText()).toBe "()"
+      editor.insertText(")")
+      expect(editor.buffer.getText()).toBe "()"
+
+    it "does not skip over brackets that have already been skipped", ->
+      editor.insertText("()")
+      editor.moveLeft()
+      editor.insertText(")")
+      expect(editor.buffer.getText()).toBe "())"
+
+    it "does skip over brackets that have already been skipped when alwaysSkipClosingPairs is set", ->
+      atom.config.set("bracket-matcher.alwaysSkipClosingPairs", true)
+      editor.insertText("()")
+      editor.moveLeft()
+      editor.insertText(")")
+      expect(editor.buffer.getText()).toBe "()"


### PR DESCRIPTION
### Description of the Change
This pull requests adds a new option (`bracket-matcher.alwaysSkipClosingPairs`) that, when enabled, will always move the cursor to the right when the cursor is behind a closing pair.

Example:
After pressing `(`, the editor will be `(|)`.
After pressing `)`, the editor will be `()|`.
After moving the cursor left, the editor will be `(|)` again.
After pressing `)` with this option set to `false`, the editor will be `()|)`
But if the option was `true`, the editor would be `()|`

### Alternate Designs
None

### Benefits
This behavior is similar to the [auto-pairs](https://github.com/jiangmiao/auto-pairs) and [delimitMate](https://github.com/Raimondi/delimitMate) Vim plugins. After switching to Atom from Vim with one of those plugins, this behavior will be much more familiar.

### Possible Drawbacks
None, this option is disabled by default.

### Applicable Issues
None