### PR TITLE
[WIP] Expand selection on repeated calls to bracket-matcher:select-inside-brackets

### DIFF
--- a/lib/bracket-matcher-view.coffee
+++ b/lib/bracket-matcher-view.coffee
@@ -277,6 +277,9 @@ class BracketMatcherView
 
       startPosition = startRange.end
       endPosition = endRange.start
+
+      startPositionExternal = startRange.start
+      endPositionExternal = endRange.end
     else
       if startPosition = @findAnyStartPair(@editor.getCursorBufferPosition())
         startPositionExternal = startPosition

--- a/lib/bracket-matcher-view.coffee
+++ b/lib/bracket-matcher-view.coffee
@@ -296,7 +296,7 @@ class BracketMatcherView
 
     if startPosition? and endPosition?
       rangeToSelect = new Range(startPosition, endPosition)
-      if @editor.getSelectedBufferRange().containsRange(rangeToSelect)
+      if rangeToSelect.isEqual(@editor.getSelectedBufferRange())
         rangeToSelect = new Range(startPositionExternal, endPositionExternal)
       @editor.setSelectedBufferRange(rangeToSelect)
 

--- a/lib/bracket-matcher-view.coffee
+++ b/lib/bracket-matcher-view.coffee
@@ -279,9 +279,11 @@ class BracketMatcherView
       endPosition = endRange.start
     else
       if startPosition = @findAnyStartPair(@editor.getCursorBufferPosition())
+        startPositionExternal = startPosition
         startPair = @editor.getTextInRange(Range.fromPointWithDelta(startPosition, 0, 1))
-        endPosition = @findMatchingEndPair(startPosition, startPair, @matchManager.pairedCharacters[startPair])
         startPosition = startPosition.traverse([0, 1])
+        endPosition = @findMatchingEndPair(startPosition, startPair, @matchManager.pairedCharacters[startPair])
+        endPositionExternal = endPosition.traverse([0, 1])
       else if pair = @tagFinder.findStartEndTags(true)
         # NOTE: findEnclosingTags is not used as it has a scope check
         # that will fail on very long lines
@@ -294,6 +296,8 @@ class BracketMatcherView
 
     if startPosition? and endPosition?
       rangeToSelect = new Range(startPosition, endPosition)
+      if @editor.getSelectedBufferRange().containsRange(rangeToSelect)
+        rangeToSelect = new Range(startPositionExternal, endPositionExternal)
       @editor.setSelectedBufferRange(rangeToSelect)
 
   # Insert at the current cursor position a closing tag if there exists an


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This is a re-implementation of #176.  On repeated calls to `bracket-matcher:select-inside-brackets`, the selection should expand to include the pairs themselves and then the next enclosing pair, etc.  For example:
(a b (**c d e**))
(a b **(c d e)**)
(**a b (c d e)**)
**(a b (c d e))**

TODO:
* [ ] Make it work with tags
* [ ] Specs

### Alternate Designs

I suppose a new command could be added, `bracket-matcher:expand-current-selection`.  However, that seems quite clunky.

### Benefits

Ability to easily expand the current selection.

### Possible Drawbacks

The command name (`select-inside-brackets`) is now a bit misleading since it will also expand the current selection.

### Applicable Issues

Supersedes and closes #176
Fixes #74