### PR TITLE
Recognize multi-line HTML tags when searching for matches

### DIFF
--- a/lib/tag-finder.coffee
+++ b/lib/tag-finder.coffee
@@ -38,7 +38,7 @@ class TagFinder
     # 4. Tag suffix
     # 5. Self-closing tag (optional)
     # 6. End tag
-    new RegExp("(<(#{tagName})(\\s+.*?)?((/)?>))|(</#{tagName}>)", 'gi')
+    new RegExp("(<(#{tagName})(\\s+[^>]*?)?((/)?>))|(</#{tagName}[^>]*>)", 'gi')
 
   isRangeCommented: (range) ->
     @scopesForPositionMatchRegex(range.start, COMMENT_SELECTOR_REGEX)

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -382,17 +382,20 @@ describe "bracket matching", ->
       describe "when the tag spans multiple lines", ->
         it "highlights the opening and closing tag", ->
           buffer.setText """
-            <test
-              a="test">
-              text
-            </test>
+            <div>
+              <div class="test"
+                title="test"
+              >
+                <div>test</div>
+              </div>
+            </div
+            >
           """
 
-          editor.setCursorBufferPosition([3, 2])
-          expectHighlights([3, 2], [0, 1])
-
           editor.setCursorBufferPosition([0, 1])
-          expectHighlights([0, 1], [3, 2])
+          expectHighlights([0, 1], [6, 2])
+          editor.setCursorBufferPosition([6, 2])
+          expectHighlights([6, 2], [0, 1])
 
       describe "when the tag has attributes", ->
         it "highlights the opening and closing tags", ->


### PR DESCRIPTION
Fixes #333

The regex for the tag's attributes used a `.` previously, which doesn't match newlines. Now it uses a `[^>]` character class which admits anything but the end of the tag, so newlines don't interfere. 

Close tags now also allow newlines before their closing bracket.