### PR TITLE
Eliminate uneccesary calls to isRangeCommentedOrString

### DIFF
--- a/lib/bracket-matcher-view.coffee
+++ b/lib/bracket-matcher-view.coffee
@@ -137,7 +137,7 @@ class BracketMatcherView
         @editor.backspace()
 
   findMatchingEndPair: (startPairPosition, startPair, endPair) ->
-    return if startPair is endPair
+    return if startPair is endPair or @isScopeCommentedOrString(@editor.scopeDescriptorForBufferPosition(startPairPosition).getScopesArray())
 
     scanRange = new Range(
       startPairPosition.traverse(ONE_CHAR_FORWARD_TRAVERSAL),
@@ -159,7 +159,7 @@ class BracketMatcherView
     endPairPosition
 
   findMatchingStartPair: (endPairPosition, startPair, endPair) ->
-    return if startPair is endPair
+    return if startPair is endPair or @isScopeCommentedOrString(@editor.scopeDescriptorForBufferPosition(endPairPosition).getScopesArray())
 
     scanRange = new Range(
       endPairPosition.traverse(MAX_ROWS_TO_SCAN_BACKWARD_TRAVERSAL),


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Fixes #341.

By design, brackets inside strings or comments are not matched. The previous behavior was that when the cursor was next to any bracket, even a bracket inside a comment or string, a search was performed for that bracket's closing pair. That search passes over comment or string scopes, so if a line read `"(example words [cursor here])"`, bracket-manager would search the entire document and ultimately fail to find a match for the last `)`, even though it should not have performed the search in the first place. This PR simply stops bracket-manager from performing these searches when the bracket in question is in a comment or string scope.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

_Do_ match brackets inside strings and comments. This has already been shown to be a bad idea.

### Benefits

<!-- What benefits will be realized by the code change? -->

Much faster performance in large files with many brackets. For instance, in [language-latex](https://github.com/area/language-latex), the following is considered a string scope: `$here is some math$` so in a long document with lots of braces (almost any medium/long math paper fits this description), either of the following, or anything similar, would cause significant lag:
`$\frac{numerator}{demonimator[cursor here]}$`
`$\sum_{n=1[cursor here]}^\infty n$`.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None.

### Applicable Issues

<!-- Enter any applicable Issues here -->

#341
James-Yu/Atom-LaTeX#131