### PR TITLE
Insert bracket pair and position cursor within a transaction

### DIFF
--- a/lib/bracket-matcher.coffee
+++ b/lib/bracket-matcher.coffee
@@ -77,8 +77,9 @@ class BracketMatcher
       @editor.moveRight()
       false
     else if autoCompleteOpeningBracket
-      @editor.insertText(text + pair)
-      @editor.moveLeft()
+      @editor.transact =>
+        @editor.insertText(text + pair)
+        @editor.moveLeft()
       range = [cursorBufferPosition, cursorBufferPosition.traverse([0, text.length])]
       @bracketMarkers.push @editor.markBufferRange(range)
       false

--- a/spec/bracket-matcher-spec.coffee
+++ b/spec/bracket-matcher-spec.coffee
@@ -803,6 +803,18 @@ describe "bracket matching", ->
         expect(buffer.lineForRow(0)).toBe "<>"
         expect(editor.getCursorBufferPosition()).toEqual([0, 1])
 
+      it "emits a buffer change event after the cursor is in place", ->
+        atom.config.set 'bracket-matcher.autocompleteCharacters', ['<>'], scopeSelector: '.source.js'
+
+        lastPosition = null
+        sub = editor.getBuffer().onDidChange ->
+          expect(lastPosition).toBeNull()
+          lastPosition = editor.getLastCursor().getBufferPosition()
+
+        editor.setCursorBufferPosition([0, 0])
+        editor.insertText '<'
+        expect(lastPosition).toEqual([0, 1])
+
     describe "when there are multiple cursors", ->
       it "inserts ) at each cursor", ->
         editor.buffer.setText("()\nab\n[]\n12")


### PR DESCRIPTION
The autocomplete-plus package uses a `TextBuffer.onDidChange()` handler to trigger the completion dropdown and uses `TextEditor.getLastCursor().getBufferPosition()` to determine its placement and prefix. Because bracket pair insertion is done with separate `.insertText()` and `.moveLeft()` calls, the `onDidChange` event is fired while the cursor is at the _end_ of the matched pair, and not when it's placed between them:

<img width="445" alt="before" src="https://user-images.githubusercontent.com/17565/37656261-e968dbee-2c1d-11e8-9563-f497b6bdd75c.png">

Performing these two calls within a transaction defers the `onDidChange` event until after the cursor is in its final position:

<img width="386" alt="after" src="https://user-images.githubusercontent.com/17565/37656278-f8f7ad24-2c1d-11e8-89ee-d589eefae65e.png">

xref atom/autocomplete-plus#954