### PR TITLE
Find brackets to highlight using the Tree-sitter syntax tree

### DIFF
--- a/lib/bracket-matcher-view.js
+++ b/lib/bracket-matcher-view.js
@@ -93,14 +93,12 @@ class BracketMatcherView {
     } else {
       this.bracket1Range = null
       this.bracket2Range = null
-      let pair
       if (this.hasSyntaxTree()) {
-        pair = this.findMatchingTagsWithSyntaxTree()
+        ({startRange, endRange} = this.findMatchingTagsWithSyntaxTree())
       } else {
-        pair = this.tagFinder.findMatchingTags()
+        ({startRange, endRange} = this.tagFinder.findMatchingTags())
       }
-      if (pair) {
-        ({startRange, endRange} = pair)
+      if (startRange) {
         highlightTag = true
         highlightPair = true
       }
@@ -221,16 +219,25 @@ class BracketMatcherView {
     return result
   }
 
-  findMatchingTagsWithSyntaxTree () {
+  findMatchingTagsWithSyntaxTree (fullRange = false) {
     const currentPosition = this.editor.getCursorBufferPosition()
     let startRange, endRange
-    const node = this.editor.buffer.getLanguageMode().getSyntaxNodeAtPosition(currentPosition, node => {
-      if (node.type.includes('element') && node.childCount > 1) {
+    const range = new Range(currentPosition, currentPosition.traverse(ONE_CHAR_FORWARD_TRAVERSAL))
+    const node = this.editor.buffer.getLanguageMode().getSyntaxNodeContainingRange(range, node => {
+      if (node.type.includes('element') && node.childCount > 0) {
         const {firstChild, lastChild} = node
         if (firstChild.childCount > 2 && firstChild.firstChild.type === '<') {
-          startRange = firstChild.child(1).range
-          if (lastChild.childCount > 2) {
-            if (lastChild.firstChild.type === '</') {
+          if (fullRange) {
+            startRange = firstChild.range
+          } else {
+            startRange = firstChild.child(1).range
+          }
+          if (lastChild === firstChild && firstChild.lastChild.type == '/>') {
+            endRange = startRange
+          } else if (lastChild.childCount > 2) {
+            if (fullRange) {
+              endRange = lastChild.range
+            } else if (lastChild.firstChild.type === '</') {
               endRange = lastChild.child(1).range
             } else if (lastChild.firstChild.type === '<' && lastChild.child(1).type === '/') {
               endRange = lastChild.child(2).range
@@ -240,7 +247,7 @@ class BracketMatcherView {
         }
       }
     })
-    if (startRange && endRange) return {startRange, endRange}
+    return {startRange, endRange}
   }
 
   findMatchingEndBracketWithRegexSearch (startBracketPosition, startBracket, endBracket) {
@@ -454,13 +461,16 @@ class BracketMatcherView {
       endRange = this.endMarker.getBufferRange()
 
       if (this.tagHighlighted) {
-        // NOTE: findEnclosingTags is not used as it has a scope check
-        // that will fail on very long lines
-        ({startRange, endRange} = this.tagFinder.findStartEndTags(true))
-      }
-
-      if (startRange.compare(endRange) > 0) {
-        [startRange, endRange] = [endRange, startRange]
+        if (this.hasSyntaxTree()) {
+          ({startRange, endRange} = this.findMatchingTagsWithSyntaxTree(true))
+        } else {
+          // NOTE: findEnclosingTags is not used as it has a scope check
+          // that will fail on very long lines
+          ({startRange, endRange} = this.tagFinder.findStartEndTags(true))
+          if (startRange && startRange.compare(endRange) > 0) {
+            [startRange, endRange] = [endRange, startRange]
+          }
+        }
       }
 
       startPosition = startRange.end
@@ -472,15 +482,18 @@ class BracketMatcherView {
         endPosition = this.findMatchingEndBracket(startPosition, startBracket, this.matchManager.pairedCharacters[startBracket])
         startPosition = startPosition.traverse([0, 1])
       } else {
-        const pair = this.tagFinder.findStartEndTags(true)
-        if (pair) {
+        if (this.hasSyntaxTree()) {
+          ({startRange, endRange} = this.findMatchingTagsWithSyntaxTree(true))
+        } else {
           // NOTE: findEnclosingTags is not used as it has a scope check
           // that will fail on very long lines
-          ({startRange, endRange} = pair)
-          if (startRange.compare(endRange) > 0) {
+          ({startRange, endRange} = this.tagFinder.findStartEndTags(true))
+          if (startRange && startRange.compare(endRange) > 0) {
             [startRange, endRange] = [endRange, startRange]
           }
+        }
 
+        if (startRange) {
           startPosition = startRange.end
           endPosition = endRange.start
         }

--- a/lib/bracket-matcher-view.js
+++ b/lib/bracket-matcher-view.js
@@ -102,7 +102,6 @@ class BracketMatcherView {
     }
 
     if (!highlightTag && !highlightPair) return
-    if (this.editor.isFoldedAtCursorRow()) return
     if (this.isCursorOnCommentOrString()) return
 
     this.startMarker = this.createMarker(startRange)
@@ -158,11 +157,66 @@ class BracketMatcherView {
   }
 
   findMatchingEndBracket (startBracketPosition, startBracket, endBracket) {
-    if (
-      startBracket === endBracket ||
-      this.isScopeCommentedOrString(this.editor.scopeDescriptorForBufferPosition(startBracketPosition).getScopesArray())
-    ) return
+    const scopeDescriptor = this.editor.scopeDescriptorForBufferPosition(startBracketPosition)
+    if (startBracket === endBracket || this.isScopeCommentedOrString(scopeDescriptor.getScopesArray())) return
 
+    if (this.editor.buffer.getLanguageMode().getSyntaxNodeAtPosition) {
+      return this.findMatchingEndBracketWithSyntaxTree(startBracketPosition, startBracket, endBracket)
+    } else {
+      return this.findMatchingEndBracketWithRegexSearch(startBracketPosition, startBracket, endBracket)
+    }
+  }
+
+  findMatchingStartBracket (endBracketPosition, startBracket, endBracket) {
+    const scopeDescriptor = this.editor.scopeDescriptorForBufferPosition(endBracketPosition)
+    if (startBracket === endBracket || this.isScopeCommentedOrString(scopeDescriptor.getScopesArray())) return
+
+    if (this.editor.buffer.getLanguageMode().getSyntaxNodeAtPosition) {
+      return this.findMatchingStartBracketWithSyntaxTree(endBracketPosition, startBracket, endBracket)
+    } else {
+      return this.findMatchingStartBracketWithRegexSearch(endBracketPosition, startBracket, endBracket)
+    }
+  }
+
+  findMatchingEndBracketWithSyntaxTree (bracketPosition, startBracket, endBracket) {
+    let result
+    const bracketEndPosition = bracketPosition.traverse([0, startBracket.length])
+    this.editor.buffer.getLanguageMode().getSyntaxNodeContainingRange(
+      new Range(bracketPosition, bracketEndPosition),
+      node => {
+        if (bracketEndPosition.isGreaterThan(node.startPosition) && bracketEndPosition.isLessThan(node.endPosition)) {
+          const matchNode = node.children.find(child =>
+            bracketEndPosition.isLessThanOrEqual(child.startPosition) &&
+            child.type === endBracket
+          )
+          if (matchNode) result = Point.fromObject(matchNode.startPosition)
+          return true
+        }
+      }
+    )
+    return result
+  }
+
+  findMatchingStartBracketWithSyntaxTree (bracketPosition, startBracket, endBracket) {
+    let result
+    const bracketEndPosition = bracketPosition.traverse([0, startBracket.length])
+    this.editor.buffer.getLanguageMode().getSyntaxNodeContainingRange(
+      new Range(bracketPosition, bracketEndPosition),
+      node => {
+        if (bracketPosition.isGreaterThan(node.startPosition)) {
+          const matchNode = node.children.find(child =>
+            bracketPosition.isGreaterThanOrEqual(child.endPosition) &&
+            child.type === startBracket
+          )
+          if (matchNode) result = Point.fromObject(matchNode.startPosition)
+          return true
+        }
+      }
+    )
+    return result
+  }
+
+  findMatchingEndBracketWithRegexSearch (startBracketPosition, startBracket, endBracket) {
     const scanRange = new Range(
       startBracketPosition.traverse(ONE_CHAR_FORWARD_TRAVERSAL),
       startBracketPosition.traverse(MAX_ROWS_TO_SCAN_FORWARD_TRAVERSAL)
@@ -188,10 +242,7 @@ class BracketMatcherView {
     return endBracketPosition
   }
 
-  findMatchingStartBracket (endBracketPosition, startBracket, endBracket) {
-    const scopeDescriptor = this.editor.scopeDescriptorForBufferPosition(endBracketPosition)
-    if (startBracket === endBracket || this.isScopeCommentedOrString(scopeDescriptor.getScopesArray())) return
-
+  findMatchingStartBracketWithRegexSearch (endBracketPosition, startBracket, endBracket) {
     const scanRange = new Range(
       endBracketPosition.traverse(MAX_ROWS_TO_SCAN_BACKWARD_TRAVERSAL),
       endBracketPosition

--- a/lib/bracket-matcher-view.js
+++ b/lib/bracket-matcher-view.js
@@ -296,6 +296,31 @@ class BracketMatcherView {
   }
 
   findPrecedingStartBracket (cursorPosition) {
+    if (this.hasSyntaxTree()) {
+      return this.findPrecedingStartBracketWithSyntaxTree(cursorPosition)
+    } else {
+      return this.findPrecedingStartBracketWithRegexSearch(cursorPosition)
+    }
+  }
+
+  findPrecedingStartBracketWithSyntaxTree (cursorPosition) {
+    let result
+    this.editor.buffer.getLanguageMode().getSyntaxNodeAtPosition(cursorPosition, node => {
+      for (const child of node.children) {
+        if (cursorPosition.isLessThanOrEqual(child.startPosition)) break
+        if (
+          child.type in this.matchManager.pairedCharacters ||
+          child.type in this.matchManager.pairedCharactersInverse
+        ) {
+          result = Point.fromObject(child.startPosition)
+          return true
+        }
+      }
+    })
+    return result
+  }
+
+  findPrecedingStartBracketWithRegexSearch (cursorPosition) {
     const scanRange = new Range(Point.ZERO, cursorPosition)
     const startBracket = _.escapeRegExp(_.keys(this.matchManager.pairedCharacters).join(''))
     const endBracket = _.escapeRegExp(_.keys(this.matchManager.pairedCharactersInverse).join(''))

--- a/lib/bracket-matcher-view.js
+++ b/lib/bracket-matcher-view.js
@@ -93,7 +93,12 @@ class BracketMatcherView {
     } else {
       this.bracket1Range = null
       this.bracket2Range = null
-      let pair = this.tagFinder.findMatchingTags()
+      let pair
+      if (this.hasSyntaxTree()) {
+        pair = this.findMatchingTagsWithSyntaxTree()
+      } else {
+        pair = this.tagFinder.findMatchingTags()
+      }
       if (pair) {
         ({startRange, endRange} = pair)
         highlightTag = true
@@ -160,7 +165,7 @@ class BracketMatcherView {
     const scopeDescriptor = this.editor.scopeDescriptorForBufferPosition(startBracketPosition)
     if (startBracket === endBracket || this.isScopeCommentedOrString(scopeDescriptor.getScopesArray())) return
 
-    if (this.editor.buffer.getLanguageMode().getSyntaxNodeAtPosition) {
+    if (this.hasSyntaxTree()) {
       return this.findMatchingEndBracketWithSyntaxTree(startBracketPosition, startBracket, endBracket)
     } else {
       return this.findMatchingEndBracketWithRegexSearch(startBracketPosition, startBracket, endBracket)
@@ -171,7 +176,7 @@ class BracketMatcherView {
     const scopeDescriptor = this.editor.scopeDescriptorForBufferPosition(endBracketPosition)
     if (startBracket === endBracket || this.isScopeCommentedOrString(scopeDescriptor.getScopesArray())) return
 
-    if (this.editor.buffer.getLanguageMode().getSyntaxNodeAtPosition) {
+    if (this.hasSyntaxTree()) {
       return this.findMatchingStartBracketWithSyntaxTree(endBracketPosition, startBracket, endBracket)
     } else {
       return this.findMatchingStartBracketWithRegexSearch(endBracketPosition, startBracket, endBracket)
@@ -214,6 +219,28 @@ class BracketMatcherView {
       }
     )
     return result
+  }
+
+  findMatchingTagsWithSyntaxTree () {
+    const currentPosition = this.editor.getCursorBufferPosition()
+    let startRange, endRange
+    const node = this.editor.buffer.getLanguageMode().getSyntaxNodeAtPosition(currentPosition, node => {
+      if (node.type.includes('element') && node.childCount > 1) {
+        const {firstChild, lastChild} = node
+        if (firstChild.childCount > 2 && firstChild.firstChild.type === '<') {
+          startRange = firstChild.child(1).range
+          if (lastChild.childCount > 2) {
+            if (lastChild.firstChild.type === '</') {
+              endRange = lastChild.child(1).range
+            } else if (lastChild.firstChild.type === '<' && lastChild.child(1).type === '/') {
+              endRange = lastChild.child(2).range
+            }
+          }
+          return true
+        }
+      }
+    })
+    if (startRange && endRange) return {startRange, endRange}
   }
 
   findMatchingEndBracketWithRegexSearch (startBracketPosition, startBracket, endBracket) {
@@ -470,5 +497,9 @@ class BracketMatcherView {
     }
 
     return false
+  }
+
+  hasSyntaxTree () {
+    return this.editor.buffer.getLanguageMode().getSyntaxNodeAtPosition
   }
 }

--- a/lib/tag-finder.js
+++ b/lib/tag-finder.js
@@ -187,7 +187,7 @@ class TagFinder {
   }
 
   findMatchingTags () {
-    if (this.isCursorOnTag()) return this.findStartEndTags()
+    return (this.isCursorOnTag() && this.findStartEndTags()) || {}
   }
 
   // Parses a fragment of html returning the stack (i.e., an array) of open tags


### PR DESCRIPTION
### Description of the Change

Currently, this package finds matching brackets by [performing a regex search and keeping track of the nesting level of bracket characters](https://github.com/atom/bracket-matcher/blob/24f4d0282e6e6ccb5fd4fbc70939e69a6a9ff21b/lib/bracket-matcher-view.js#L160-L189). The code for finding matching HTML tags is [even more complicated](https://github.com/atom/bracket-matcher/blob/24f4d0282e6e6ccb5fd4fbc70939e69a6a9ff21b/lib/tag-finder.js).

In this PR, I've updated the package to find matching tokens using syntax trees provided by [Tree-sitter](https://blog.github.com/2018-10-31-atoms-new-parsing-system/), when they are available.

### Benefits

The performance of bracket matching is vastly improved. Here's a flame graph that I recorded in the current version of Atom when moving the cursor across [this opening parenthesis](https://github.com/atom/atom/blob/36d185fa4d1e2b56d3d4a2ee2ce977e83984030c/spec/text-editor-component-spec.js#L31) in Atom's `text-editor-component-spec.js`.

![screen shot 2018-11-16 at 2 46 03 pm](https://user-images.githubusercontent.com/326587/48651735-1ffda580-e9b1-11e8-864f-816b21913e7a.png)

This operation took **300ms**.

Here's a flame graph that I recorded of the same operation with this fix:

![screen shot 2018-11-16 at 3 08 30 pm](https://user-images.githubusercontent.com/326587/48651830-81be0f80-e9b1-11e8-9c91-097e4158ea95.png)

The operation now takes **0.75ms**; the syntax tree makes the operation basically free.

### Possible Drawbacks

This improvement only takes effect for languages with Tree-sitter parsers.

### Applicable Issues

Fixes #348
Fixes #355
