### PR TITLE
Don't highlight HTML tags when the cursor is between them

### DIFF
--- a/lib/bracket-matcher-view.js
+++ b/lib/bracket-matcher-view.js
@@ -94,7 +94,7 @@ class BracketMatcherView {
       this.bracket1Range = null
       this.bracket2Range = null
       if (this.hasSyntaxTree()) {
-        ({startRange, endRange} = this.findMatchingTagsWithSyntaxTree())
+        ({startRange, endRange} = this.findMatchingTagNameRangesWithSyntaxTree())
       } else {
         ({startRange, endRange} = this.tagFinder.findMatchingTags())
         if (this.isCursorOnCommentOrString()) return
@@ -221,36 +221,65 @@ class BracketMatcherView {
     return result
   }
 
-  findMatchingTagsWithSyntaxTree (fullRange = false) {
-    const currentPosition = this.editor.getCursorBufferPosition()
-    let startRange, endRange
-    const range = new Range(currentPosition, currentPosition.traverse(ONE_CHAR_FORWARD_TRAVERSAL))
-    const node = this.editor.buffer.getLanguageMode().getSyntaxNodeContainingRange(range, node => {
-      if (node.type.includes('element') && node.childCount > 0) {
-        const {firstChild, lastChild} = node
-        if (firstChild.childCount > 2 && firstChild.firstChild.type === '<') {
-          if (fullRange) {
-            startRange = firstChild.range
-          } else {
-            startRange = firstChild.child(1).range
-          }
-          if (lastChild === firstChild && firstChild.lastChild.type == '/>') {
-            endRange = startRange
-          } else if (lastChild.childCount > 2) {
-            if (fullRange) {
-              endRange = lastChild.range
-            } else if (lastChild.firstChild.type === '</') {
-              endRange = lastChild.child(1).range
-            } else if (lastChild.firstChild.type === '<' && lastChild.child(1).type === '/') {
-              endRange = lastChild.child(2).range
-            }
-          }
-          return true
+  findMatchingTagNameRangesWithSyntaxTree () {
+    const position = this.editor.getCursorBufferPosition()
+    const {startTag, endTag} = this.findContainingTagsWithSyntaxTree(position)
+    if (startTag && (startTag.range.containsPoint(position) || endTag.range.containsPoint(position))) {
+      if (startTag === endTag) {
+        const {range} = startTag.child(1)
+        return {startRange: range, endRange: range}
+      } else if (endTag.firstChild.type === '</') {
+        return {
+          startRange: startTag.child(1).range,
+          endRange: endTag.child(1).range
+        }
+      } else {
+        return {
+          startRange: startTag.child(1).range,
+          endRange: endTag.child(2).range
         }
       }
+    } else {
+      return {}
+    }
+  }
+
+  findMatchingTagsWithSyntaxTree () {
+    const position = this.editor.getCursorBufferPosition()
+    const {startTag, endTag} = this.findContainingTagsWithSyntaxTree(position)
+    if (startTag) {
+      return {startRange: startTag.range, endRange: endTag.range}
+    } else {
+      return {}
+    }
+  }
+
+  findContainingTagsWithSyntaxTree (position) {
+    let startTag, endTag
+    const range = new Range(position, position.traverse(ONE_CHAR_FORWARD_TRAVERSAL))
+    this.editor.buffer.getLanguageMode().getSyntaxNodeContainingRange(range, node => {
+      if (node.type.includes('element') && node.childCount > 0) {
+        const {firstChild, lastChild} = node
+        if (
+          firstChild.childCount > 2 &&
+          firstChild.firstChild.type === '<'
+        ) {
+          if (lastChild === firstChild && firstChild.lastChild.type === '/>') {
+            startTag = firstChild
+            endTag = firstChild
+          } else if (
+            lastChild.childCount > 2 &&
+            (lastChild.firstChild.type === '</' ||
+             lastChild.firstChild.type === '<' && lastChild.child(1).type === '/')
+          ) {
+            startTag = firstChild
+            endTag = lastChild
+          }
+        }
+        return true
+      }
     })
-    if (!endRange) startRange = null
-    return {startRange, endRange}
+    return {startTag, endTag}
   }
 
   findMatchingEndBracketWithRegexSearch (startBracketPosition, startBracket, endBracket) {
@@ -465,7 +494,7 @@ class BracketMatcherView {
 
       if (this.tagHighlighted) {
         if (this.hasSyntaxTree()) {
-          ({startRange, endRange} = this.findMatchingTagsWithSyntaxTree(true))
+          ({startRange, endRange} = this.findMatchingTagsWithSyntaxTree())
         } else {
           // NOTE: findEnclosingTags is not used as it has a scope check
           // that will fail on very long lines
@@ -486,7 +515,7 @@ class BracketMatcherView {
         startPosition = startPosition.traverse([0, 1])
       } else {
         if (this.hasSyntaxTree()) {
-          ({startRange, endRange} = this.findMatchingTagsWithSyntaxTree(true))
+          ({startRange, endRange} = this.findMatchingTagsWithSyntaxTree())
         } else {
           // NOTE: findEnclosingTags is not used as it has a scope check
           // that will fail on very long lines

--- a/spec/bracket-matcher-spec.js
+++ b/spec/bracket-matcher-spec.js
@@ -326,7 +326,7 @@ describe('bracket matching', () => {
         })
 
         describe('when on an opening tag', () => {
-          it('highlight the opening and closing tag', () => {
+          it('highlights the opening and closing tag', () => {
             buffer.setText(`\
 <test>
   <test>text</test>
@@ -344,7 +344,7 @@ describe('bracket matching', () => {
         })
 
         describe('when on a closing tag', () => {
-          it('highlight the opening and closing tag', () => {
+          it('highlights the opening and closing tag', () => {
             buffer.setText(`\
 <test>
   <!-- <test> -->
@@ -524,6 +524,14 @@ describe('bracket matching', () => {
           it('does not highlight anything', () => {
             buffer.setText('<test>\ntext\n')
             editor.setCursorBufferPosition([0, 10])
+            expectNoHighlights()
+          })
+        })
+
+        describe('when between the opening and closing tag', () => {
+          it('does not highlight anything', () => {
+            buffer.setText('<div>\nhi\n</div>\n')
+            editor.setCursorBufferPosition([1, 0])
             expectNoHighlights()
           })
         })


### PR DESCRIPTION
Fixes #374.

For some reason, I thought that behavior (highlighting matching tags when the cursor was in between them) was the expected behavior. Nope. Thanks for pointing that out @Aerijo! 😓 