### PR TITLE
Fix exception when running select-inside-brackets command w/o tree-si…

### DIFF
--- a/lib/tag-finder.js
+++ b/lib/tag-finder.js
@@ -144,7 +144,7 @@ class TagFinder {
   }
 
   findStartEndTags (fullRange = false) {
-    let ranges = null
+    let ranges = {}
     const endPosition = this.editor.getLastCursor().getCurrentWordBufferRange({wordRegex: this.wordRegex}).end
     this.editor.backwardsScanInBufferRange(this.tagPattern, [[0, 0], endPosition], ({match, range, stop}) => {
       stop()

--- a/spec/bracket-matcher-spec.js
+++ b/spec/bracket-matcher-spec.js
@@ -751,6 +751,13 @@ describe('bracket matching', () => {
       })
     })
 
+    it('does not error when a bracket is already highlighted (regression)', () => {
+      atom.grammars.assignLanguageMode(editor, null)
+      editor.setText("(ok)")
+      editor.selectAll()
+      atom.commands.dispatch(editorElement, 'bracket-matcher:select-inside-brackets')
+    })
+
     forEachLanguageWithTags(scopeName => {
       describe(`${scopeName} tag matching`, () => {
         beforeEach(() => {


### PR DESCRIPTION
Fixes https://github.com/atom/bracket-matcher/issues/376

Thanks @robrix for the heads up on this.