### PR TITLE
Deactivate cleanly

### DIFF
--- a/lib/bracket-matcher-view.js
+++ b/lib/bracket-matcher-view.js
@@ -56,9 +56,7 @@ class BracketMatcherView {
 
       atom.commands.add(editorElement, 'bracket-matcher:select-matching-brackets', () =>
         this.selectMatchingBrackets()
-      ),
-
-      this.editor.onDidDestroy(() => this.dispose())
+      )
     )
 
     this.updateMatch()

--- a/lib/bracket-matcher-view.js
+++ b/lib/bracket-matcher-view.js
@@ -66,6 +66,10 @@ class BracketMatcherView {
 
   dispose () {
     this.subscriptions.dispose()
+    if (this.pairHighlighted) {
+      this.editor.destroyMarker(this.startMarker.id)
+      this.editor.destroyMarker(this.endMarker.id)
+    }
   }
 
   updateMatch () {

--- a/lib/bracket-matcher-view.js
+++ b/lib/bracket-matcher-view.js
@@ -13,7 +13,6 @@ const MAX_ROWS_TO_SCAN_BACKWARD_TRAVERSAL = Object.freeze(Point(-MAX_ROWS_TO_SCA
 module.exports =
 class BracketMatcherView {
   constructor (editor, editorElement, matchManager) {
-    this.destroy = this.destroy.bind(this)
     this.updateMatch = this.updateMatch.bind(this)
     this.editor = editor
     this.matchManager = matchManager
@@ -59,13 +58,13 @@ class BracketMatcherView {
         this.selectMatchingBrackets()
       ),
 
-      this.editor.onDidDestroy(this.destroy)
+      this.editor.onDidDestroy(() => this.dispose())
     )
 
     this.updateMatch()
   }
 
-  destroy () {
+  dispose () {
     this.subscriptions.dispose()
   }
 

--- a/lib/bracket-matcher.js
+++ b/lib/bracket-matcher.js
@@ -23,7 +23,7 @@ class BracketMatcher {
         if (!this.removeBrackets()) event.abortKeyBinding()
       }),
 
-      this.editor.onDidDestroy(() => this.unsubscribe())
+      this.editor.onDidDestroy(() => this.dispose())
     )
   }
 
@@ -270,7 +270,7 @@ class BracketMatcher {
     return this.matchManager.pairedCharacters[firstCharacter] === lastCharacter
   }
 
-  unsubscribe () {
+  dispose () {
     this.subscriptions.dispose()
   }
 

--- a/lib/bracket-matcher.js
+++ b/lib/bracket-matcher.js
@@ -21,9 +21,7 @@ class BracketMatcher {
     this.subscriptions.add(
       atom.commands.add(editorElement, 'bracket-matcher:remove-brackets-from-selection', event => {
         if (!this.removeBrackets()) event.abortKeyBinding()
-      }),
-
-      this.editor.onDidDestroy(() => this.dispose())
+      })
     )
   }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -28,10 +28,8 @@ module.exports = {
   deactivate () {
     this.subscriptions.dispose()
     for (const editor of atom.workspace.getTextEditors()) {
-      if (this.watchedEditors.has(editor)) {
-        this.watchedEditors.get(editor).dispose()
-        this.watchedEditors.delete(editor)
-      }
+      this.watchedEditors.get(editor).dispose()
+      this.watchedEditors.delete(editor)
     }
   }
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,20 +1,33 @@
+const CompositeDisposable = require('atom')
+
 const MatchManager = require('./match-manager')
 const BracketMatcherView = require('./bracket-matcher-view')
 const BracketMatcher = require('./bracket-matcher')
 
 module.exports = {
   activate () {
-    const watchedEditors = new WeakSet()
+    this.watchedEditors = new WeakMap()
 
     atom.workspace.observeTextEditors(editor => {
-      if (watchedEditors.has(editor)) return
+      if (this.watchedEditors.has(editor)) return
 
       const editorElement = atom.views.getView(editor)
-      const matchManager = new MatchManager(editor, editorElement)
-      new BracketMatcherView(editor, editorElement, matchManager)
-      new BracketMatcher(editor, editorElement, matchManager)
-      watchedEditors.add(editor)
-      editor.onDidDestroy(() => watchedEditors.delete(editor))
+      const matchManager = new MatchManager(editor)
+      const bracketMatcherView = new BracketMatcherView(editor, editorElement, matchManager)
+      const bracketMatcher = new BracketMatcher(editor, editorElement, matchManager)
+      const subscriptions = new CompositeDisposable([matchManager, bracketMatcherView, bracketMatcher])
+      this.watchedEditors.add(editor, subscriptions)
+      editor.onDidDestroy(() => {
+        this.watchedEditors.get(editor).dispose()
+        this.watchedEditors.delete(editor)
+      })
     })
+  },
+
+  deactivate () {
+    for (const editor of atom.workspace.getTextEditors()) {
+      this.watchedEditors.get(editor).dispose()
+      this.watchedEditors.delete(editor)
+    }
   }
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -7,8 +7,9 @@ const BracketMatcher = require('./bracket-matcher')
 module.exports = {
   activate () {
     this.watchedEditors = new WeakMap()
+    this.subscriptions = new CompositeDisposable()
 
-    atom.workspace.observeTextEditors(editor => {
+    this.subscriptions.add(atom.workspace.observeTextEditors(editor => {
       if (this.watchedEditors.has(editor)) return
 
       const editorElement = atom.views.getView(editor)
@@ -17,16 +18,15 @@ module.exports = {
       const bracketMatcher = new BracketMatcher(editor, editorElement, matchManager)
       const subscriptions = new CompositeDisposable(matchManager, bracketMatcherView, bracketMatcher)
       this.watchedEditors.set(editor, subscriptions)
-      editor.onDidDestroy(() => {
-        if (this.watchedEditors.has(editor)) {
-          this.watchedEditors.get(editor).dispose()
-          this.watchedEditors.delete(editor)
-        }
-      })
-    })
+      this.subscriptions.add(editor.onDidDestroy(() => {
+        this.watchedEditors.get(editor).dispose()
+        this.watchedEditors.delete(editor)
+      }))
+    }))
   },
 
   deactivate () {
+    this.subscriptions.dispose()
     for (const editor of atom.workspace.getTextEditors()) {
       if (this.watchedEditors.has(editor)) {
         this.watchedEditors.get(editor).dispose()

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,4 +1,4 @@
-const CompositeDisposable = require('atom')
+const {CompositeDisposable} = require('atom')
 
 const MatchManager = require('./match-manager')
 const BracketMatcherView = require('./bracket-matcher-view')
@@ -15,19 +15,23 @@ module.exports = {
       const matchManager = new MatchManager(editor)
       const bracketMatcherView = new BracketMatcherView(editor, editorElement, matchManager)
       const bracketMatcher = new BracketMatcher(editor, editorElement, matchManager)
-      const subscriptions = new CompositeDisposable([matchManager, bracketMatcherView, bracketMatcher])
-      this.watchedEditors.add(editor, subscriptions)
+      const subscriptions = new CompositeDisposable(matchManager, bracketMatcherView, bracketMatcher)
+      this.watchedEditors.set(editor, subscriptions)
       editor.onDidDestroy(() => {
-        this.watchedEditors.get(editor).dispose()
-        this.watchedEditors.delete(editor)
+        if (this.watchedEditors.has(editor)) {
+          this.watchedEditors.get(editor).dispose()
+          this.watchedEditors.delete(editor)
+        }
       })
     })
   },
 
   deactivate () {
     for (const editor of atom.workspace.getTextEditors()) {
-      this.watchedEditors.get(editor).dispose()
-      this.watchedEditors.delete(editor)
+      if (this.watchedEditors.has(editor)) {
+        this.watchedEditors.get(editor).dispose()
+        this.watchedEditors.delete(editor)
+      }
     }
   }
 }

--- a/lib/match-manager.js
+++ b/lib/match-manager.js
@@ -36,8 +36,7 @@ class MatchManager {
     return atom.config.get(key, {scope: this.editor.getRootScopeDescriptor()})
   }
 
-  constructor (editor, editorElement) {
-    this.destroy = this.destroy.bind(this)
+  constructor (editor) {
     this.editor = editor
     this.subscriptions = new CompositeDisposable()
 
@@ -48,13 +47,13 @@ class MatchManager {
     this.subscriptions.add(
       atom.config.observe('bracket-matcher.autocompleteCharacters', {scope}, () => this.updateConfig()),
       atom.config.observe('bracket-matcher.pairsWithExtraNewline', {scope}, () => this.updateConfig()),
-      this.editor.onDidDestroy(this.destroy)
+      this.editor.onDidDestroy(() => this.dispose())
     )
 
     this.changeBracketsMode = false
   }
 
-  destroy () {
+  dispose () {
     this.subscriptions.dispose()
   }
 }

--- a/lib/match-manager.js
+++ b/lib/match-manager.js
@@ -47,7 +47,6 @@ class MatchManager {
     this.subscriptions.add(
       atom.config.observe('bracket-matcher.autocompleteCharacters', {scope}, () => this.updateConfig()),
       atom.config.observe('bracket-matcher.pairsWithExtraNewline', {scope}, () => this.updateConfig()),
-      this.editor.onDidDestroy(() => this.dispose())
     )
 
     this.changeBracketsMode = false


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

bracket-matcher does not deactivate cleanly - that is, it continues to match brackets and provide bracket autocompletion even after it is deactivated. This is because none of its subscriptions are disposed upon deactivation.
We now keep track of the `observeTextEditors` and `editor.onDidDestroy` subscriptions and dispose of them so that bracket-matcher does not continue matching brackets whenever a new editor is opened. Furthermore, upon deactivation/editor destruction, we now dispose of all the subscriptions that we create per-editor (this additionally means that each class no longer has to individually subscribe to the `editor.onDidDestroy`).

### Alternate Designs

Coming later

### Benefits

Deactivation will work.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #156

Todo:
* [ ] Is the `watchedEditors.has` check in `observeTextEditors` necessary? Seems to me like we're disposing of everything in `editor.onDidDestroy`, so we shouldn't need a `has` check when a new editor is added.
* [ ] Specs