### PR TITLE
Tweak syntax tree range query to work w/ new Tree-sitter

### DIFF
--- a/lib/bracket-matcher-view.js
+++ b/lib/bracket-matcher-view.js
@@ -256,8 +256,8 @@ class BracketMatcherView {
 
   findContainingTagsWithSyntaxTree (position) {
     let startTag, endTag
-    const range = new Range(position, position.traverse(ONE_CHAR_FORWARD_TRAVERSAL))
-    this.editor.buffer.getLanguageMode().getSyntaxNodeContainingRange(range, node => {
+    if (position.column === this.editor.buffer.lineLengthForRow(position.row)) position.column--;
+    this.editor.buffer.getLanguageMode().getSyntaxNodeAtPosition(position, node => {
       if (node.type.includes('element') && node.childCount > 0) {
         const {firstChild, lastChild} = node
         if (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bracket-matcher",
-  "version": "0.91.0",
+  "version": "0.91.1-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bracket-matcher",
-  "version": "0.91.0",
+  "version": "0.91.1-0",
   "main": "./lib/main",
   "description": "Highlight the matching bracket for the `(){}[]` character under the cursor. Move the cursor to the matching bracket with `ctrl-m`.",
   "repository": "https://github.com/atom/bracket-matcher",


### PR DESCRIPTION
This goes along with https://github.com/atom/atom/pull/19531.