### PR TITLE
Fix close-tag for JSX tags with member access

### DIFF
--- a/lib/tag-finder.js
+++ b/lib/tag-finder.js
@@ -16,7 +16,7 @@ const generateTagStartOrEndRegex = function (tagNameRegexStr) {
   return new RegExp(`<(${tagNameRegexStr})${notSelfClosingTagEnd}|<\\/(${tagNameRegexStr})>`)
 }
 
-const tagStartOrEndRegex = generateTagStartOrEndRegex('\\w[-\\w]*(?:\\:\\w[-\\w]*)?')
+const tagStartOrEndRegex = generateTagStartOrEndRegex('\\w[-\\w]*(?:(?:\\:|\\.)\\w[-\\w]*)*')
 
 // Helper to find the matching start/end tag for the start/end tag under the
 // cursor in XML, HTML, etc. editors.

--- a/spec/close-tag-spec.js
+++ b/spec/close-tag-spec.js
@@ -96,6 +96,43 @@ describe('closeTag', () => {
       expect(tagFinder.closingTagForFragments(preFragment, postFragment)).toBe('my-element')
     })
 
+    it('correctly closes tags containing attributes', () => {
+      const preFragment = '<html><head></head><body class="foo bar"><div>'
+      const postFragment = '</body></html>'
+      expect(tagFinder.closingTagForFragments(preFragment, postFragment)).toBe('div')
+    })
+
+    it('correctly closes tags containing an XML namespace', () => {
+      const preFragment = '<html><head></head><body><custom:tag>'
+      const postFragment = '</body></html>'
+      expect(tagFinder.closingTagForFragments(preFragment, postFragment)).toBe('custom:tag')
+    })
+
+    it('correctly closes tags containing multiple XML namespaces', () => {
+      // This is not exactly valid syntax but it can't hurt to support it
+      const preFragment = '<html><head></head><body><custom:custom2:tag>'
+      const postFragment = '</body></html>'
+      expect(tagFinder.closingTagForFragments(preFragment, postFragment)).toBe('custom:custom2:tag')
+    })
+
+    it('correctly closes tags in the present of JSX tags containing member accesses', () => {
+        const preFragment = '<Foo><Bar.Baz></Bar.Baz>'
+        const postFragment = ''
+        expect(tagFinder.closingTagForFragments(preFragment, postFragment)).toBe('Foo')
+    })
+
+    it('correctly closes JSX tags containing member accesses', () => {
+        const preFragment = '<Foo.Bar><div></div>'
+        const postFragment = ''
+        expect(tagFinder.closingTagForFragments(preFragment, postFragment)).toBe('Foo.Bar')
+    })
+
+    it('correctly closes JSX tags containing deep member accesses', () => {
+        const preFragment = '<Foo.Bar.Baz><div></div>'
+        const postFragment = ''
+        expect(tagFinder.closingTagForFragments(preFragment, postFragment)).toBe('Foo.Bar.Baz')
+    })
+
     it('correctly closes tags when there are other tags with the same prefix', () => {
       const preFragment = '<thead><th>'
       const postFragment = '</thead>'


### PR DESCRIPTION
### Description of the Change

Adjust the regex used to find matching tags. The regex was extended to support a dot (`.`) in the middle of the tag so that member access in JSX is now supported (e.g. `<Grid.Row>`). To support deep member access the existing suffix part of the regex was changed from zero or once `?` to N times `*`. This now also enables deep nesting of XML namespaces (`<custom:test:tag>`).

I also added a test case containing attributes. I didn't change anything about that but I wanted to make sure that that behavior is tested.

### Alternate Designs

To my knowledge deep nesting of XML namespace is not valid. So we could have just not allowed it but this way the regex stays simpler.

In addition, using deeply nested XML namespaces would have resulted in strange behavior. Now it is what the user would expect. I.e. just closing the tag no matter what.

### Benefits

JSX Tags with member access can now be closed. Before the change:

```jsx
<Foo.Bar>
/* closing the tag here resulted in </Foo> instead of </Foo.Bar>  */
```

```jsx
<div>
<Foo.Bar></Foo.Bar>
/* closing the tag here resulted in </Foo> instead of </div> */
```


### Possible Drawbacks

This should have no performance impact but might perhaps break tag matching in some cases.
I can't think of anything and all tests are passing but regexes are fragile.

### Applicable Issues

No issue yet
